### PR TITLE
Added Video Playback on Mac

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'cpp', 'java' ]
+        language: [ 'cpp' ]
 
     steps:
     - name: Checkout repository


### PR DESCRIPTION
Supported file format is `.mp4` files which contain `H.264` for video and `AAC` for audio.

@KyouBrayden Could you update the document? This feature will be released in 2.11.4.