### PR TITLE
Added Linux video playback

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -30,7 +30,7 @@ jobs:
     - name: Build Suika2 on Linux
       run: |
         sudo apt update
-        sudo apt install -y libasound2-dev libx11-dev libxpm-dev mesa-common-dev
+        sudo apt install -y libasound2-dev libx11-dev libxpm-dev mesa-common-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev
         cd build/linux-x86_64
         ./build-libs.sh
         make

--- a/build/web-kit/readme-en.html
+++ b/build/web-kit/readme-en.html
@@ -103,7 +103,7 @@
 <ul>
   <li>Rev.48 23rd October 2022
     <ul>
-      <li>Supported Suika 2.11.4</li>
+      <li>Support Suika 2.11.4</li>
     </ul>
   </li>
   <li>Rev.47 22nd October 2022

--- a/build/web-kit/readme-en.html
+++ b/build/web-kit/readme-en.html
@@ -44,7 +44,7 @@
 <body>
 
 <h1>Suika2 for Web Browsers Distribution Kit</h1>
-<p>Rev.47 (Supports Suika 2.11.3)</p>
+<p>Rev.48 (Supports Suika 2.11.4)</p>
 <p>Copyright (c) 2022 the Suika2 Development Team. All rights reserved.</p>
 
 <h2>About this kit</h2>
@@ -101,6 +101,11 @@
 
 <h2>Revisions</h2>
 <ul>
+  <li>Rev.48 23rd October 2022
+    <ul>
+      <li>Supported Suika 2.11.4</li>
+    </ul>
+  </li>
   <li>Rev.47 22nd October 2022
     <ul>
       <li>Support Suika 2.11.3</li>

--- a/build/web-kit/readme-jp.html
+++ b/build/web-kit/readme-jp.html
@@ -44,7 +44,7 @@
 <body>
 
 <h1>Suika2 Webブラウザ版 配布キット</h1>
-<p>Rev.47 (Suika 2.11.3対応)</p>
+<p>Rev.48 (Suika 2.11.4対応)</p>
 <p>Copyright (c) 2022 the Suika2 Development Team. All rights reserved.</p>
 
 <h2>このキットについて</h2>
@@ -97,6 +97,11 @@
 
 <h2>変更履歴</h2>
 <ul>
+  <li>Rev.48 2022/10/23
+    <ul>
+      <li>Suika 2.11.4に対応</li>
+    </ul>
+  </li>
   <li>Rev.47 2022/10/22
     <ul>
       <li>Suika 2.11.3に対応</li>

--- a/doc/reference.md
+++ b/doc/reference.md
@@ -696,8 +696,8 @@ Shows two levels of two options, four in total.
 This command plays a video file.
 At the moment, this functionality is enabled on Windows and Mac only.
 
-On Windows, please use `.wmv` video file format.
-On Mac, please use `.mp4` video file format.
+On Windows, please use the `.wmv` video file format.
+On Mac, please use the `.mp4` video file format.
 
 Video files are stored in `mov` directory.
 `mov` directory is not stored in `data01.arc` file.

--- a/doc/reference.md
+++ b/doc/reference.md
@@ -694,10 +694,10 @@ Shows two levels of two options, four in total.
 ## @video
 
 This command plays a video file.
-At the moment, this functionality is enabled on Windows only.
+At the moment, this functionality is enabled on Windows and Mac only.
 
-Recommended video file format is `.WMV` file because of royalty fee.
-It is not recommended, but `.AVI` file which contains `H.264` + `AAC` is also supported on Windows 10/11.
+On Windows, please use `.wmv` video file format.
+On Mac, please use `.mp4` video file format.
 
 Video files are stored in `mov` directory.
 `mov` directory is not stored in `data01.arc` file.

--- a/readme-en.html
+++ b/readme-en.html
@@ -42,7 +42,7 @@
 </head>
 <body>
 
-<h1>Suika 2.11.3</h1>
+<h1>Suika 2.11.4</h1>
 <p>Copyright (c) 2022 the Suika2 Development Team. All rights reserved.</p>
 
 <h2>About Suika2</h2>
@@ -174,6 +174,14 @@ Suika2 is an open-source, cross-platform visual novel development engine that al
 
 <h2>Release History</h2>
 <ul>
+  <li>Suika 2.11.4 2022/10/23
+    <ul>
+			<li>Added movie playback functionality on Mac</li>
+			<li>Added Release Mode which enables installation to Program Files folder on Windows</li>
+			<li>Fixed a bug that caused the window title to change when loading</li>
+			<li>Fixed crash when viewing history immediately after loading</li>
+		</ul>
+  </li>
   <li>Suika 2.11.3 22nd October 2022
     <ul>
 			<li>Add the feature of displaying the character's face on the left side of the message box</li>

--- a/readme-jp.html
+++ b/readme-jp.html
@@ -43,7 +43,7 @@
 </head>
 <body>
 
-<h1>Suika 2.11.3</h1>
+<h1>Suika 2.11.4</h1>
 <p>Copyright (c) 2022 the Suika2 Development Team. All rights reserved.</p>
 
 <h2>このソフトについて</h2>
@@ -165,6 +165,14 @@
 
 <h2>変更履歴</h2>
 <ul>
+  <li>Suika 2.11.4 2022/10/23
+    <ul>
+			<li>Macでの動画再生に対応</li>
+			<li>Program Filesへのインストールに対応</li>
+			<li>ロードすると必ずウィンドウタイトルに章タイトルが反映される問題を修正</li>
+			<li>ロード直後にログを表示するとクラッシュする問題を修正</li>
+		</ul>
+  </li>
   <li>Suika 2.11.3 2022/10/22
     <ul>
 			<li>メッセージボックスの左にキャラの顔を表示する機能を追加</li>

--- a/src/x11main.c
+++ b/src/x11main.c
@@ -945,6 +945,7 @@ static int get_key_code(XEvent *event)
 	/* キーコードに変換する */
 	switch (keysym) {
 	case XK_Return:
+	case XK_KP_Enter:
 		return KEY_RETURN;
 	case XK_space:
 		return KEY_SPACE;


### PR DESCRIPTION
This PR adds video playback ability on Linux.

Any video file format that Gstreamer supports is acceptable. Here, we recommend MP4 (H.264+AAC) to unify with Mac (and Windows in future).

Also, numpad Enter key support is added.