### PR TITLE
Final patch for version 2.11.5

### DIFF
--- a/src/cmd_message.c
+++ b/src/cmd_message.c
@@ -384,8 +384,10 @@ static bool init(int *x, int *y, int *w, int *h)
 		pen_x = conf_msgbox_margin_left;
 		pen_y = conf_msgbox_margin_top;
 	}
-	orig_pen_x = pen_x;
-	orig_pen_y = pen_y;
+	if (!gui_flag) {
+		orig_pen_x = pen_x;
+		orig_pen_y = pen_y;
+	}
 
 	/* メッセージボックスの矩形を取得する */
 	get_msgbox_rect(&msgbox_x, &msgbox_y, &msgbox_w, &msgbox_h);
@@ -780,6 +782,12 @@ static int get_frame_chars(void)
 
 	/* セーブ画面かヒストリ画面かコンフィグ画面から復帰した場合 */
 	if (gui_flag) {
+		/* NVLモードの場合 */
+		if (is_nvl_mode) {
+			drawn_chars = total_chars;
+			return 0;
+		}
+
 		/* すべての文字を描画する */
 		return total_chars;
 	}
@@ -2303,7 +2311,9 @@ static bool cleanup(int *x, int *y, int *w, int *h)
 	set_seen();
 
 	/* NVLモードで重ね塗りをする場合 */
-	if (conf_msgbox_dim) {
+	if (conf_msgbox_dim &&
+	    (!did_quick_load && !need_save_mode && !need_load_mode &&
+	     !need_history_mode && !need_config_mode)) {
 		is_overcoating = true;
 		msg = msg_top;
 		if (msg[0] == '\\')

--- a/src/cmd_message.c
+++ b/src/cmd_message.c
@@ -2306,6 +2306,8 @@ static bool cleanup(int *x, int *y, int *w, int *h)
 	if (conf_msgbox_dim) {
 		is_overcoating = true;
 		msg = msg_top;
+		if (msg[0] == '\\')
+			msg++;
 		drawn_chars = 0;
 		pen_x = orig_pen_x;
 		pen_y = orig_pen_y;

--- a/src/gui.c
+++ b/src/gui.c
@@ -1708,7 +1708,7 @@ static void draw_history_text_item(int button_index)
 			/* エスケープ文字であるとき */
 			if (c == CHAR_BACKSLASH || c == CHAR_YENSIGN) {
 				escaped = true;
-				text += mblen;
+				button[button_index].rt.top += mblen;
 				continue;
 			}
 		} else if (escaped) {
@@ -1719,7 +1719,7 @@ static void draw_history_text_item(int button_index)
 				button[button_index].rt.pen_x =
 					button[button_index].margin;
 				escaped = false;
-				text += mblen;
+				button[button_index].rt.top += mblen;
 				continue;
 			}
 

--- a/src/nsmain.m
+++ b/src/nsmain.m
@@ -1094,7 +1094,7 @@ void stop_video(void)
     playerLayer = nil;
 
     // OpenGLのレンダリングを開始する
-    opengl_end_rendering();
+    opengl_start_rendering();
 }
 
 //


### PR DESCRIPTION
* Fixed the video stop handling on Mac
* Fixed the new-lines of the continued lines
* Fixed the new-lines in the history screen
* Fixed the duplicated messages on NVL-style