### PR TITLE
Added GitHub Actions workflow for Android apk

### DIFF
--- a/.github/workflows/suika-android.yml
+++ b/.github/workflows/suika-android.yml
@@ -17,8 +17,8 @@ jobs:
           wget https://dl.google.com/android/repository/commandlinetools-linux-8512546_latest.zip
           unzip commandlinetools-linux-8512546_latest.zip
           export ANDROID_SDK_ROOT=`pwd`/cmdline-tools
-          unset ANDROID_HOME
           export ANDROID_NDK_HOME=$ANDROID_NDK_ROOT/ndk
+          unset ANDROID_HOME
           unset ANDROID_NDK
           unset NDK_ROOT
           yes | ./cmdline-tools/bin/sdkmanager --licenses --sdk_root=$ANDROID_SDK_ROOT

--- a/.github/workflows/suika-android.yml
+++ b/.github/workflows/suika-android.yml
@@ -17,7 +17,7 @@ jobs:
           wget https://dl.google.com/android/repository/commandlinetools-linux-8512546_latest.zip
           unzip commandlinetools-linux-8512546_latest.zip
           export ANDROID_SDK_ROOT=`pwd`/cmdline-tools
-          yes | ./cmdline-tools/bin/sdkmanager --licenses
+          yes | ./cmdline-tools/bin/sdkmanager --licenses --sdk_root=$ANDROID_SDK_ROOT
           ./cmdline-tools/bin/sdkmanager "platforms;android-30" --sdk_root=$ANDROID_SDK_ROOT
           ./prepare-libs.sh
           ./gradlew build

--- a/.github/workflows/suika-android.yml
+++ b/.github/workflows/suika-android.yml
@@ -20,7 +20,7 @@ jobs:
           yes | ./cmdline-tools/bin/sdkmanager --licenses --sdk_root=$ANDROID_SDK_ROOT
           ./cmdline-tools/bin/sdkmanager "platforms;android-30" --sdk_root=$ANDROID_SDK_ROOT
           ./prepare-libs.sh
-          ./gradlew build --stacktrace --debug
+          ./gradlew build --stacktrace
       - name: Upload
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/suika-android.yml
+++ b/.github/workflows/suika-android.yml
@@ -14,23 +14,15 @@ jobs:
           sudo apt update
           sudo apt install -y android-sdk
           cd build/android
+          ./prepare-libs.sh
           wget https://dl.google.com/android/repository/commandlinetools-linux-8512546_latest.zip
           unzip commandlinetools-linux-8512546_latest.zip
           export ANDROID_SDK_ROOT=`pwd`/cmdline-tools
           unset ANDROID_HOME
           yes | ./cmdline-tools/bin/sdkmanager --licenses --sdk_root=$ANDROID_SDK_ROOT
-          ./cmdline-tools/bin/sdkmanager "platforms;android-30" --sdk_root=$ANDROID_SDK_ROOT
-          ./prepare-libs.sh
-      - name: Build2
-        continue-on-error: true
-        run: |
-          cd build/android
-          gradle clean
-          ./gradlew
-          ./gradlew build --stacktrace
-      - name: Build3
-        run: |
-          cd build/android
+          gradle clean || true
+          ./gradlew || true
+          ./gradlew build --stacktrace || true
           ./cmdline-tools/bin/sdkmanager "platforms;android-30" --sdk_root=$ANDROID_SDK_ROOT
           ./gradlew build --stacktrace
       - name: Upload

--- a/.github/workflows/suika-android.yml
+++ b/.github/workflows/suika-android.yml
@@ -9,11 +9,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Build
+      - name: Build1
         run: |
           sudo apt update
-          sudo apt install -y openjdk-11-jdk
-          sudo apt remove -y android-sdk
+          sudo apt install -y android-sdk
           cd build/android
           wget https://dl.google.com/android/repository/commandlinetools-linux-8512546_latest.zip
           unzip commandlinetools-linux-8512546_latest.zip
@@ -22,9 +21,15 @@ jobs:
           yes | ./cmdline-tools/bin/sdkmanager --licenses --sdk_root=$ANDROID_SDK_ROOT
           ./cmdline-tools/bin/sdkmanager "platforms;android-30" --sdk_root=$ANDROID_SDK_ROOT
           ./prepare-libs.sh
-          export ANDROID_SDK_ROOT=`pwd`/cmdline-tools
-          export ANDROID_NDK_HOME=$ANDROID_NDK_ROOT/ndk
-          unset ANDROID_HOME
+          gradle clean
+          ./gradlew
+      - name: Build2
+        continue-on-error: true
+        run: |
+          ./gradlew build --stacktrace
+      - name: Build3
+        run: |
+          ./cmdline-tools/bin/sdkmanager "platforms;android-30" --sdk_root=$ANDROID_SDK_ROOT
           ./gradlew build --stacktrace
       - name: Upload
         uses: actions/upload-artifact@v2

--- a/.github/workflows/suika-android.yml
+++ b/.github/workflows/suika-android.yml
@@ -17,7 +17,7 @@ jobs:
           wget https://dl.google.com/android/repository/commandlinetools-linux-8512546_latest.zip
           unzip commandlinetools-linux-8512546_latest.zip
           export ANDROID_SDK_ROOT=`pwd`/cmdline-tools
-	  export ANDROID_HOME=$ANDROID_SDK_ROOT
+          export ANDROID_HOME=$ANDROID_SDK_ROOT
           yes | ./cmdline-tools/bin/sdkmanager --licenses --sdk_root=$ANDROID_SDK_ROOT
           ./cmdline-tools/bin/sdkmanager "platforms;android-30" --sdk_root=$ANDROID_SDK_ROOT
           ./prepare-libs.sh

--- a/.github/workflows/suika-android.yml
+++ b/.github/workflows/suika-android.yml
@@ -21,6 +21,7 @@ jobs:
           yes | ./cmdline-tools/bin/sdkmanager --licenses --sdk_root=$ANDROID_SDK_ROOT
           ./cmdline-tools/bin/sdkmanager "platforms;android-30" --sdk_root=$ANDROID_SDK_ROOT
           ./prepare-libs.sh
+          export ANDROID_NDK_HOME=$ANDROID_SDK_ROOT/ndk/24.0.8215888
           ./gradlew build
       - name: Upload
         uses: actions/upload-artifact@v2

--- a/.github/workflows/suika-android.yml
+++ b/.github/workflows/suika-android.yml
@@ -13,17 +13,18 @@ jobs:
         run: |
           sudo apt update
           sudo apt install -y openjdk-11-jdk
+          sudo apt remove -y android-sdk
           cd build/android
           wget https://dl.google.com/android/repository/commandlinetools-linux-8512546_latest.zip
           unzip commandlinetools-linux-8512546_latest.zip
           export ANDROID_SDK_ROOT=`pwd`/cmdline-tools
-          export ANDROID_NDK_HOME=$ANDROID_NDK_ROOT/ndk
           unset ANDROID_HOME
-          unset ANDROID_NDK
-          unset NDK_ROOT
           yes | ./cmdline-tools/bin/sdkmanager --licenses --sdk_root=$ANDROID_SDK_ROOT
           ./cmdline-tools/bin/sdkmanager "platforms;android-30" --sdk_root=$ANDROID_SDK_ROOT
           ./prepare-libs.sh
+          export ANDROID_SDK_ROOT=`pwd`/cmdline-tools
+          export ANDROID_NDK_HOME=$ANDROID_NDK_ROOT/ndk
+          unset ANDROID_HOME
           ./gradlew build --stacktrace
       - name: Upload
         uses: actions/upload-artifact@v2

--- a/.github/workflows/suika-android.yml
+++ b/.github/workflows/suika-android.yml
@@ -17,6 +17,7 @@ jobs:
           wget https://dl.google.com/android/repository/commandlinetools-linux-8512546_latest.zip
           unzip commandlinetools-linux-8512546_latest.zip
           export ANDROID_SDK_ROOT=`pwd`/cmdline-tools
+	  export ANDROID_HOME=$ANDROID_SDK_ROOT
           yes | ./cmdline-tools/bin/sdkmanager --licenses --sdk_root=$ANDROID_SDK_ROOT
           ./cmdline-tools/bin/sdkmanager "platforms;android-30" --sdk_root=$ANDROID_SDK_ROOT
           ./prepare-libs.sh

--- a/.github/workflows/suika-android.yml
+++ b/.github/workflows/suika-android.yml
@@ -12,16 +12,14 @@ jobs:
       - name: Build
         run: |
           sudo apt update
-          sudo apt install -y android-sdk
+          sudo apt install -y openjdk-11-jdk
           cd build/android
           wget https://dl.google.com/android/repository/commandlinetools-linux-8512546_latest.zip
           unzip commandlinetools-linux-8512546_latest.zip
           export ANDROID_SDK_ROOT=`pwd`/cmdline-tools
-          export ANDROID_HOME=$ANDROID_SDK_ROOT
           yes | ./cmdline-tools/bin/sdkmanager --licenses --sdk_root=$ANDROID_SDK_ROOT
           ./cmdline-tools/bin/sdkmanager "platforms;android-30" --sdk_root=$ANDROID_SDK_ROOT
           ./prepare-libs.sh
-          export ANDROID_NDK_HOME=$ANDROID_SDK_ROOT/ndk
           ./gradlew build --stacktrace --debug
       - name: Upload
         uses: actions/upload-artifact@v2

--- a/.github/workflows/suika-android.yml
+++ b/.github/workflows/suika-android.yml
@@ -22,9 +22,7 @@ jobs:
           ./cmdline-tools/bin/sdkmanager "platforms;android-30" --sdk_root=$ANDROID_SDK_ROOT
           ./prepare-libs.sh
           export ANDROID_NDK_HOME=$ANDROID_SDK_ROOT/ndk
-          gradle clean
-          ./gradlew --stacktrace
-          ./gradlew build --stacktrace
+          ./gradlew build --stacktrace --debug
       - name: Upload
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/suika-android.yml
+++ b/.github/workflows/suika-android.yml
@@ -21,7 +21,7 @@ jobs:
           yes | ./cmdline-tools/bin/sdkmanager --licenses --sdk_root=$ANDROID_SDK_ROOT
           ./cmdline-tools/bin/sdkmanager "platforms;android-30" --sdk_root=$ANDROID_SDK_ROOT
           ./prepare-libs.sh
-          export ANDROID_NDK_HOME=$ANDROID_SDK_ROOT/ndk/24.0.8215888
+          export ANDROID_NDK_HOME=$ANDROID_SDK_ROOT/ndk
           ./gradlew build --stacktrace
       - name: Upload
         uses: actions/upload-artifact@v2

--- a/.github/workflows/suika-android.yml
+++ b/.github/workflows/suika-android.yml
@@ -22,7 +22,7 @@ jobs:
           ./cmdline-tools/bin/sdkmanager "platforms;android-30" --sdk_root=$ANDROID_SDK_ROOT
           ./prepare-libs.sh
           export ANDROID_NDK_HOME=$ANDROID_SDK_ROOT/ndk/24.0.8215888
-          ./gradlew build
+          ./gradlew build --stacktrace
       - name: Upload
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/suika-android.yml
+++ b/.github/workflows/suika-android.yml
@@ -22,6 +22,7 @@ jobs:
           ./cmdline-tools/bin/sdkmanager "platforms;android-30" --sdk_root=$ANDROID_SDK_ROOT
           ./prepare-libs.sh
           export ANDROID_NDK_HOME=$ANDROID_SDK_ROOT/ndk
+          gradle clean
           ./gradlew --stacktrace
           ./gradlew build --stacktrace
       - name: Upload

--- a/.github/workflows/suika-android.yml
+++ b/.github/workflows/suika-android.yml
@@ -21,11 +21,11 @@ jobs:
           yes | ./cmdline-tools/bin/sdkmanager --licenses --sdk_root=$ANDROID_SDK_ROOT
           ./cmdline-tools/bin/sdkmanager "platforms;android-30" --sdk_root=$ANDROID_SDK_ROOT
           ./prepare-libs.sh
-          gradle clean
-          ./gradlew
       - name: Build2
         continue-on-error: true
         run: |
+          gradle clean
+          ./gradlew
           ./gradlew build --stacktrace
       - name: Build3
         run: |

--- a/.github/workflows/suika-android.yml
+++ b/.github/workflows/suika-android.yml
@@ -18,7 +18,7 @@ jobs:
           unzip commandlinetools-linux-8512546_latest.zip
           export ANDROID_SDK_ROOT=`pwd`/cmdline-tools
           unset ANDROID_HOME
-          unset ANDROID_NDK_HOME=$ANDROID_NDK_ROOT/ndk
+          export ANDROID_NDK_HOME=$ANDROID_NDK_ROOT/ndk
           unset ANDROID_NDK
           unset NDK_ROOT
           yes | ./cmdline-tools/bin/sdkmanager --licenses --sdk_root=$ANDROID_SDK_ROOT

--- a/.github/workflows/suika-android.yml
+++ b/.github/workflows/suika-android.yml
@@ -18,6 +18,9 @@ jobs:
           unzip commandlinetools-linux-8512546_latest.zip
           export ANDROID_SDK_ROOT=`pwd`/cmdline-tools
           unset ANDROID_HOME
+          unset ANDROID_NDK_HOME
+          unset ANDROID_NDK
+          unset NDK_ROOT
           yes | ./cmdline-tools/bin/sdkmanager --licenses --sdk_root=$ANDROID_SDK_ROOT
           ./cmdline-tools/bin/sdkmanager "platforms;android-30" --sdk_root=$ANDROID_SDK_ROOT
           ./prepare-libs.sh

--- a/.github/workflows/suika-android.yml
+++ b/.github/workflows/suika-android.yml
@@ -17,6 +17,7 @@ jobs:
           wget https://dl.google.com/android/repository/commandlinetools-linux-8512546_latest.zip
           unzip commandlinetools-linux-8512546_latest.zip
           export ANDROID_SDK_ROOT=`pwd`/cmdline-tools
+          unset ANDROID_HOME
           yes | ./cmdline-tools/bin/sdkmanager --licenses --sdk_root=$ANDROID_SDK_ROOT
           ./cmdline-tools/bin/sdkmanager "platforms;android-30" --sdk_root=$ANDROID_SDK_ROOT
           ./prepare-libs.sh

--- a/.github/workflows/suika-android.yml
+++ b/.github/workflows/suika-android.yml
@@ -22,6 +22,7 @@ jobs:
           ./cmdline-tools/bin/sdkmanager "platforms;android-30" --sdk_root=$ANDROID_SDK_ROOT
           ./prepare-libs.sh
           export ANDROID_NDK_HOME=$ANDROID_SDK_ROOT/ndk
+          ./gradlew --stacktrace
           ./gradlew build --stacktrace
       - name: Upload
         uses: actions/upload-artifact@v2

--- a/.github/workflows/suika-android.yml
+++ b/.github/workflows/suika-android.yml
@@ -5,7 +5,7 @@ on:
 jobs:
   android:
     runs-on: "ubuntu-22.04"
-    name: linux
+    name: android
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/suika-android.yml
+++ b/.github/workflows/suika-android.yml
@@ -1,0 +1,28 @@
+name: suika-android
+on:
+  push:
+  pull_request:
+jobs:
+  android:
+    runs-on: "ubuntu-22.04"
+    name: linux
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Build
+        run: |
+          sudo apt update
+          sudo apt install -y android-sdk
+          cd build/android
+          wget https://dl.google.com/android/repository/commandlinetools-linux-8512546_latest.zip
+          unzip commandlinetools-linux-8512546_latest.zip
+          export ANDROID_SDK_ROOT=`pwd`/cmdline-tools
+          yes | ./cmdline-tools/bin/sdkmanager --licenses
+          ./cmdline-tools/bin/sdkmanager "platforms;android-30" --sdk_root=$ANDROID_SDK_ROOT
+          ./prepare-libs.sh
+          ./gradlew build
+      - name: Upload
+        uses: actions/upload-artifact@v2
+        with:
+          name: suika.apk
+          path: build/android/app/build/outputs/apk/debug/app-debug.apk

--- a/.github/workflows/suika-android.yml
+++ b/.github/workflows/suika-android.yml
@@ -24,11 +24,13 @@ jobs:
       - name: Build2
         continue-on-error: true
         run: |
+          cd build/android
           gradle clean
           ./gradlew
           ./gradlew build --stacktrace
       - name: Build3
         run: |
+          cd build/android
           ./cmdline-tools/bin/sdkmanager "platforms;android-30" --sdk_root=$ANDROID_SDK_ROOT
           ./gradlew build --stacktrace
       - name: Upload

--- a/.github/workflows/suika-android.yml
+++ b/.github/workflows/suika-android.yml
@@ -18,7 +18,7 @@ jobs:
           unzip commandlinetools-linux-8512546_latest.zip
           export ANDROID_SDK_ROOT=`pwd`/cmdline-tools
           unset ANDROID_HOME
-          unset ANDROID_NDK_HOME
+          unset ANDROID_NDK_HOME=$ANDROID_NDK_ROOT/ndk
           unset ANDROID_NDK
           unset NDK_ROOT
           yes | ./cmdline-tools/bin/sdkmanager --licenses --sdk_root=$ANDROID_SDK_ROOT

--- a/build/android/app/build.gradle
+++ b/build/android/app/build.gradle
@@ -28,6 +28,9 @@ android {
             path "CMakeLists.txt"
         }
     }
+    lintOptions {
+        abortOnError false
+    }
 }
 
 dependencies {

--- a/build/android/gradle.properties
+++ b/build/android/gradle.properties
@@ -12,3 +12,9 @@ org.gradle.jvmargs=-Xmx1536m
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
 org.gradle.warning.mode=all
+org.gradle.jvmargs=-Xmx1536M \
+--add-exports=java.base/sun.nio.ch=ALL-UNNAMED \
+--add-opens=java.base/java.lang=ALL-UNNAMED \
+--add-opens=java.base/java.lang.reflect=ALL-UNNAMED \
+--add-opens=java.base/java.io=ALL-UNNAMED \
+--add-exports=jdk.unsupported/sun.misc=ALL-UNNAMED


### PR DESCRIPTION
@innocentvoice

Interestingly, I've found that we need to fail three times in the build process.
I've added ` || true` to ignore the commands that fail.

Please refer to `suika-android.yml` when building with Codespaces.
In that case, though, you will need an additional `export JAVA_HOME=/usr` to avoid using Java17.