### PR TITLE
Fixed so that commands don't proceed while the menubar is displayed

### DIFF
--- a/.github/workflows/suika-linux.yml
+++ b/.github/workflows/suika-linux.yml
@@ -23,7 +23,7 @@ jobs:
           echo Installing mesa-common-dev
           sudo apt-get install -y mesa-common-dev
           echo Removing libunwind-dev...
-          sudo apt-get remove -y libunwind-dev
+          sudo apt-get remove -y libunwind-dev libunwind-14-dev
           echo Installing libgstreamer1.0-dev
           sudo apt-get install -y libgstreamer1.0-dev
           echo Installing libgstreamer-plugins-base1.0-dev

--- a/build/mingw-64/Makefile
+++ b/build/mingw-64/Makefile
@@ -25,6 +25,7 @@ CPPFLAGS = \
 
 CFLAGS = \
 	-O3 \
+	-municode \
 	-ffast-math \
 	-fopt-info-vec \
 	-std=gnu89 \
@@ -42,6 +43,7 @@ CFLAGS = \
 
 LDFLAGS = \
 	-mwindows \
+	-municode \
 	-lgdi32 \
 	-lole32 \
 	-ldxguid \
@@ -51,7 +53,8 @@ LDFLAGS = \
 	-lopengl32 \
 	-ld3d9 \
 	-L./libroot/lib \
-	-Wl,-dn,-ljpeg,-lpng16,-lz,-lvorbisfile,-lvorbis,-logg,-lfreetype,-dy
+	-Wl,-dn,-ljpeg,-lpng16,-lz,-lvorbisfile,-lvorbis,-logg,-lfreetype,-dy \
+	-Wl,--gc-sections
 
 #
 # Source files
@@ -61,6 +64,7 @@ SRCS_C = \
 	$(SRCS_COMMON) \
 	$(SRCS_SSE) \
 	../../src/winmain.c \
+	../../src/uimsg.c \
 	../../src/glrender.c \
 	../../src/d3drender.c \
 	../../src/dsound.c

--- a/build/mingw-64/build-libs.sh
+++ b/build/mingw-64/build-libs.sh
@@ -49,7 +49,6 @@ sed -e 's/FONT_MODULES += type1//' \
     -e 's/FONT_MODULES += cid//' \
     -e 's/FONT_MODULES += pfr//' \
     -e 's/FONT_MODULES += type42//' \
-    -e 's/FONT_MODULES += winfonts//' \
     -e 's/FONT_MODULES += pcf//' \
     -e 's/FONT_MODULES += bdf//' \
     -e 's/FONT_MODULES += pshinter//' \

--- a/doc/requirements-specification.md
+++ b/doc/requirements-specification.md
@@ -492,7 +492,8 @@ The following is the list of effects types.
 |close slit                                |`slit-close`        |              |               |
 |open slit (vertical)                      |`slit-open-v`       |              |               |
 |close slit (vertical)                     |`slit-close-v`      |              |               |
-|rule (universal transition)               |`rule:<rule-file>`  |              |               |
+|rule (universal transition/1-bit)         |`rule:<rule-file>`  |              |               |
+|melt (universal transition/8-bit)         |`melt:<rule-file>`  |              |               |
 
 The `mask` Effect type was removed as the `rule` effect type was introduced.
 The demo includes a `rule-mask.png` file as a rule image corresponding to `mask`, therefore `rule:rule-mask.png` works fine.
@@ -531,9 +532,17 @@ The applicable effect type is "close eyes", which is like closing eyes slowly.
 ### Usage 5
 
 The following script changes the background image to `sample.png` with a 1.5 second fade-in time.
-The applicable effect type is "rule (universal transition)", which uses `rule-star.png` image for transition rule.
+The applicable effect type is "rule (universal transition/1-bit)", which uses `rule-star.png` image for transition rule.
 ```
 @bg sample.png 1.5 rule:rule-star.png
+```
+
+### Usage 6
+
+The following script changes the background image to `sample.png` with a 1.5 second fade-in time.
+The applicable effect type is "melt (universal transition/8-bit)", which uses `rule-star.png` image for transition rule.
+```
+@bg sample.png 1.5 melt:rule-star.png
 ```
 
 ## Showing a Character (`@ch`)

--- a/src/sdlmain.c
+++ b/src/sdlmain.c
@@ -513,6 +513,17 @@ void render_image_rule(struct image * RESTRICT src_img,
 }
 
 /*
+ * Render an image to the screen with a rule image, using the melt effect.
+ */
+void render_image_melt(struct image * RESTRICT src_img,
+		       struct image * RESTRICT rule_img,
+		       int threshold)
+{
+	/* See also glrender.c */
+	opengl_render_image_melt(src_img, rule_img, threshold);
+}
+
+/*
  * File manipulation
  */
 


### PR DESCRIPTION
I really wanted to continue executing the command while the menu was displayed.
However, it was not easy to implement multi-threaded processing running on Direct3D 9.0, OpenGL, and GDI.
Basically, these are single-threaded.

So I decided to stop the command time while the menu is displayed.

The countermeasure would be to move to DirectX 11.
But since it would raise the necessary hardware requirements, we have taken this action for now.

I will resolve this issue in the future.