### PR TITLE
Suika2/12.8

### DIFF
--- a/build/macos/suika.xcodeproj/project.pbxproj
+++ b/build/macos/suika.xcodeproj/project.pbxproj
@@ -657,7 +657,7 @@
 				);
 				LIBRARY_SEARCH_PATHS = libroot/lib;
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
-				MARKETING_VERSION = 2.12.7;
+				MARKETING_VERSION = 2.12.8;
 				OTHER_CFLAGS = (
 					"-DXCODE",
 					"-DUSE_DEBUGGER",
@@ -702,7 +702,7 @@
 				);
 				LIBRARY_SEARCH_PATHS = libroot/lib;
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
-				MARKETING_VERSION = 2.12.7;
+				MARKETING_VERSION = 2.12.8;
 				OTHER_CFLAGS = (
 					"-DXCODE",
 					"-DUSE_DEBUGGER",
@@ -860,7 +860,7 @@
 				);
 				LIBRARY_SEARCH_PATHS = libroot/lib;
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
-				MARKETING_VERSION = 2.12.7;
+				MARKETING_VERSION = 2.12.8;
 				OTHER_CFLAGS = (
 					"-DXCODE",
 					"-ffast-math",
@@ -905,7 +905,7 @@
 				);
 				LIBRARY_SEARCH_PATHS = libroot/lib;
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
-				MARKETING_VERSION = 2.12.7;
+				MARKETING_VERSION = 2.12.8;
 				OTHER_CFLAGS = (
 					"-DXCODE",
 					"-ffast-math",

--- a/build/release/readme-en.html
+++ b/build/release/readme-en.html
@@ -42,7 +42,7 @@
 </head>
 <body>
 
-<h1>Suika 2/12.7</h1>
+<h1>Suika 2/12.8</h1>
 <p>Copyright (c) 2023 the Suika2 Development Team. All rights reserved.</p>
 
 <h2>About Suika2</h2>
@@ -168,6 +168,13 @@ Suika2 is an open-source, cross-platform visual novel development engine that al
 
 <h2>Release History</h2>
 <ul>
+  <li>Suika 2/12.8 11th June 2023
+    <ul>
+      <li>Fixed the bug that the Japanese "stop" specifier is not usable in the @se command (Thanks to Ameno-san!)</li>
+      <li>Added the feature to clear the message history (Thanks to Ameno-san!)</li>
+      <li>Added a config to quote Japanese lines (<code>serif.quote</code>) (Thanks to Saito-san!)</li>
+    </ul>
+  </li>
   <li>Suika 2/12.7 10th June 2023
     <ul>
       <li>Fixed the ch command bug with Japanese argument</li>

--- a/build/release/readme-jp.html
+++ b/build/release/readme-jp.html
@@ -43,7 +43,7 @@
 </head>
 <body>
 
-<h1>Suika 2/12.7</h1>
+<h1>Suika 2/12.8</h1>
 <p>Copyright (c) 2023 the Suika2 Development Team. All rights reserved.</p>
 
 <h2>このソフトについて</h2>
@@ -162,6 +162,13 @@
 
 <h2>変更履歴</h2>
 <ul>
+  <li>Suika 2/12.8 2023/06/11
+    <ul>
+      <li>効果音コマンドで日本語の「停止」が使えない問題を修正 (Thanks to アメノ-san!)</li>
+      <li>メッセージ履歴をクリアする機能を追加 (Thanks to アメノ-san!)</li>
+      <li>日本語のセリフをカギカッコで囲うコンフィグ <code>serif.quote</code> を追加 (Thanks to サイト-san!)</li>
+    </ul>
+  </li>
   <li>Suika 2/12.7 2023/06/10
     <ul>
       <li>CHコマンドで日本語を使ったときのバグ修正(Thanks to SOrow-san!)</li>

--- a/build/web-kit/readme-en.html
+++ b/build/web-kit/readme-en.html
@@ -44,7 +44,7 @@
 <body>
 
 <h1>Suika2 for Web Browsers Distribution Kit</h1>
-<p>Rev.62 (Supports Suika 2/12.7)</p>
+<p>Rev.63 (Supports Suika 2/12.8)</p>
 <p>Copyright (c) 2023 the Suika2 Development Team. All rights reserved.</p>
 
 <h2>About this kit</h2>
@@ -101,6 +101,11 @@
 
 <h2>Revisions</h2>
 <ul>
+  <li>Rev.63 11th June 2023
+    <ul>
+      <li>Support Suika 2/12.8</li>
+    </ul>
+  </li>
   <li>Rev.62 10th June 2023
     <ul>
       <li>Support Suika 2/12.7</li>

--- a/build/web-kit/readme-jp.html
+++ b/build/web-kit/readme-jp.html
@@ -44,7 +44,7 @@
 <body>
 
 <h1>Suika2 Webブラウザ版 配布キット</h1>
-<p>Rev.62 (Suika 2/12.7対応)</p>
+<p>Rev.63 (Suika 2/12.8対応)</p>
 <p>Copyright (c) 2023 the Suika2 Development Team. All rights reserved.</p>
 
 <h2>このキットについて</h2>
@@ -97,6 +97,11 @@
 
 <h2>変更履歴</h2>
 <ul>
+  <li>Rev.63 2023/6/11
+    <ul>
+      <li>Suika 2/12.8に対応</li>
+    </ul>
+  </li>
   <li>Rev.62 2023/6/10
     <ul>
       <li>Suika 2/12.7に対応</li>

--- a/doc/requirements-specification.md
+++ b/doc/requirements-specification.md
@@ -3292,7 +3292,7 @@ value = s2_random();
 
 ### Overwriting a Configuration
 
-The following functions overwrites a configuration:
+The following function overwrites a configuration:
 
 * `s2_set_config(): accepts a string key and a string value.
 
@@ -3315,6 +3315,15 @@ s2_set_config("msgbox.bg.file", "msgbox-bg.png");
 ```
 s2_reflect_msgbox_and_namebox_config();
 ```
+
+### Clearing Message History
+
+`s2_clear_history()` clears the message history.
+
+```
+s2_clear_history();
+```
+
 
 ***
 

--- a/game-en/conf/config.txt
+++ b/game-en/conf/config.txt
@@ -124,6 +124,62 @@ msgbox.btn.hide.y=16
 msgbox.btn.hide.width=29
 msgbox.btn.hide.height=29
 
+# [Unused in the sample]
+# Position of the save button (position inside message box, optional)
+# msgbox.btn.save.x=0
+# msgbox.btn.save.y=0
+# msgbox.btn.save.width=0
+# msgbox.btn.save.height=0
+
+# [Unused in the sample]
+# Position of the load button (position inside message box, optional)
+# msgbox.btn.load.x=0
+# msgbox.btn.load.y=0
+# msgbox.btn.load.width=0
+# msgbox.btn.load.height=0
+
+# [Unused in the sample]
+# Position of the qsave button (position inside message box, optional)
+# msgbox.btn.qsave.x=0
+# msgbox.btn.qsave.y=0
+# msgbox.btn.qsave.width=0
+# msgbox.btn.qsave.height=0
+
+# [Unused in the sample]
+# Position of the qload button (position inside message box, optional)
+# msgbox.btn.qload.x=0
+# msgbox.btn.qload.y=0
+# msgbox.btn.qload.width=0
+# msgbox.btn.qload.height=0
+
+# [Unused in the sample]
+# Position of the auto button (position inside message box, optional)
+# msgbox.btn.auto.x=0
+# msgbox.btn.auto.y=0
+# msgbox.btn.auto.width=0
+# msgbox.btn.auto.height=0
+
+# [Unused in the sample]
+# Position of the skip button (position inside message box, optional)
+# msgbox.btn.skip.x=0
+# msgbox.btn.skip.y=0
+# msgbox.btn.skip.width=0
+# msgbox.btn.skip.height=0
+
+# [Unused in the sample]
+# Position of the history button (position inside message box, optional)
+# msgbox.btn.history.x=0
+# msgbox.btn.history.y=0
+# msgbox.btn.history.width=0
+# msgbox.btn.history.height=0
+
+# [Unused in the sample]
+# Position of the config button (position inside message box, optional)
+# msgbox.btn.config.x=0
+# msgbox.btn.config.y=0
+# msgbox.btn.config.width=0
+# msgbox.btn.config.height=0
+
 # Sound effect when pointed button changed (optional)
 msgbox.btn.change.se=btn-change.ogg
 

--- a/game-jp/conf/config.txt
+++ b/game-jp/conf/config.txt
@@ -98,6 +98,62 @@ msgbox.btn.hide.y=16
 msgbox.btn.hide.width=29
 msgbox.btn.hide.height=29
 
+# [サンプルでは未使用]
+# メッセージボックス内のセーブボタンの座標(メッセージボックス内の座標, 省略可)
+# msgbox.btn.save.x=0
+# msgbox.btn.save.y=0
+# msgbox.btn.save.width=0
+# msgbox.btn.save.height=0
+
+# [サンプルでは未使用]
+# メッセージボックス内のロードボタンの座標(メッセージボックス内の座標, 省略可)
+# msgbox.btn.load.x=0
+# msgbox.btn.load.y=0
+# msgbox.btn.load.width=0
+# msgbox.btn.load.height=0
+
+# [サンプルでは未使用]
+# メッセージボックス内のクイックセーブボタンの座標(メッセージボックス内の座標, 省略可)
+# msgbox.btn.qsave.x=0
+# msgbox.btn.qsave.y=0
+# msgbox.btn.qsave.width=0
+# msgbox.btn.qsave.height=0
+
+# [サンプルでは未使用]
+# メッセージボックス内のクイックロードボタンの座標(メッセージボックス内の座標, 省略可)
+# msgbox.btn.qload.x=0
+# msgbox.btn.qload.y=0
+# msgbox.btn.qload.width=0
+# msgbox.btn.qload.height=0
+
+# [サンプルでは未使用]
+# メッセージボックス内のオートボタンの座標(メッセージボックス内の座標, 省略可)
+# msgbox.btn.auto.x=0
+# msgbox.btn.auto.y=0
+# msgbox.btn.auto.width=0
+# msgbox.btn.auto.height=0
+
+# [サンプルでは未使用]
+# メッセージボックス内のスキップボタンの座標(メッセージボックス内の座標, 省略可)
+# msgbox.btn.skip.x=0
+# msgbox.btn.skip.y=0
+# msgbox.btn.skip.width=0
+# msgbox.btn.skip.height=0
+
+# [サンプルでは未使用]
+# メッセージボックス内のログボタンの座標(メッセージボックス内の座標, 省略可)
+# msgbox.btn.history.x=0
+# msgbox.btn.history.y=0
+# msgbox.btn.history.width=0
+# msgbox.btn.history.height=0
+
+# [サンプルでは未使用]
+# メッセージボックス内のコンフィグボタンの座標(メッセージボックス内の座標, 省略可)
+# msgbox.btn.config.x=0
+# msgbox.btn.config.y=0
+# msgbox.btn.config.width=0
+# msgbox.btn.config.height=0
+
 # ポイントされているボタンが変化したときのSE(省略可)
 msgbox.btn.change.se=btn-change.ogg
 
@@ -424,6 +480,9 @@ msgbox.show.on.ch=0
 
 # 背景の変更中にメッセージボックスを隠さない (1:隠さない, 0:隠す) (省略可)
 msgbox.show.on.bg=0
+
+# セリフをカギカッコで囲う (1:囲う, 0:囲わない) (省略可)
+serif.quote=0
 
 ###
 ### リリースモード

--- a/game-jp/wms/clear-history.txt
+++ b/game-jp/wms/clear-history.txt
@@ -1,0 +1,4 @@
+func main() {
+     // メッセージ履歴を消去します
+     s2_clear_history();
+}

--- a/src/cmd_message.c
+++ b/src/cmd_message.c
@@ -173,7 +173,7 @@ static bool init(int *x, int *y, int *w, int *h);
 static char *quote_serif(const char *msg);
 static void init_auto_mode(void);
 static void init_skip_mode(void);
-static bool register_message_for_history(void);
+static bool register_message_for_history(const char *reg_msg);
 static bool process_serif_command(int *x, int *y, int *w, int *h);
 static void draw_namebox(void);
 static int get_namebox_width(void);
@@ -377,7 +377,7 @@ static bool init(int *x, int *y, int *w, int *h)
 		return false;
 
 	/* ヒストリ画面用にメッセージ履歴を登録する */
-	if (!register_message_for_history())
+	if (!register_message_for_history(exp_msg))
 		return false;
 
 	/* 文字色を求める */
@@ -519,7 +519,7 @@ static void init_skip_mode(void)
 }
 
 /* ヒストリ画面用にメッセージ履歴を登録する */
-static bool register_message_for_history(void)
+static bool register_message_for_history(const char *reg_msg)
 {
 	const char *name;
 	const char *voice;
@@ -544,7 +544,7 @@ static bool register_message_for_history(void)
 	}
 
 	/* ヒストリ画面用に登録する */
-	if (!register_message(name, msg, voice))
+	if (!register_message(name, reg_msg, voice))
 		return false;
 
 	return true;

--- a/src/cmd_se.c
+++ b/src/cmd_se.c
@@ -23,11 +23,17 @@ bool se_command(void)
 	const char *fname;
 	const char *option;
 	int stream;
-	bool loop;
+	bool loop, stop;
 
 	/* パラメータを取得する */
 	fname = get_string_param(SE_PARAM_FILE);
 	option = get_string_param(SE_PARAM_OPTION);
+
+	/* 停止の指示かどうかチェックする */
+	if (strcmp(fname, "stop") == 0 || strcmp(fname, U8("停止")) == 0)
+		stop = true;
+	else
+		stop = false;
 
 	/*
 	 * 1. voice指示の有無を確認する
@@ -47,14 +53,15 @@ bool se_command(void)
 	}
 
 	/* 停止の指示でない場合 */
-	w = NULL;
-	if (strcmp(fname, "stop") != 0) {
+	if (!stop) {
 		/* PCMストリームをオープンする */
 		w = create_wave_from_file(SE_DIR, fname, loop);
 		if (w == NULL) {
 			log_script_exec_footer();
 			return false;
 		}
+	} else {
+		w = NULL;
 	}
 
 	/* 再生を開始する */

--- a/src/conf.c
+++ b/src/conf.c
@@ -369,6 +369,9 @@ int conf_msgbox_show_on_bg;
 /* ビープの調整 */
 float conf_beep_adjustment;
 
+/* セリフをカギカッコで囲う */
+int conf_serif_quote;
+
 /* リリース版であるか */
 int conf_release;
 
@@ -1075,6 +1078,7 @@ struct rule {
 	{"msgbox.show.on.ch", 'i', &conf_msgbox_show_on_ch, true, false},
 	{"msgbox.show.on.bg", 'i', &conf_msgbox_show_on_bg, true, false},
 	{"beep.adjustment", 'f', &conf_beep_adjustment, true, false},
+	{"serif.quote", 'i', &conf_serif_quote, true, false},
 	{"release", 'i', &conf_release, true, false},
 };
 

--- a/src/conf.h
+++ b/src/conf.h
@@ -333,6 +333,7 @@ extern int conf_click_disable;
 extern int conf_msgbox_show_on_ch;
 extern int conf_msgbox_show_on_bg;
 extern float conf_beep_adjustment;
+extern int conf_serif_quote;
 extern int conf_release;
 
 /* conf_localeを設定する */

--- a/src/wms_impl.c
+++ b/src/wms_impl.c
@@ -18,6 +18,7 @@ static bool s2_random(struct wms_runtime *rt);
 static bool s2_set_config(struct wms_runtime *rt);
 static bool s2_reflect_msgbox_and_namebox_config(struct wms_runtime *rt);
 static bool s2_reflect_font_config(struct wms_runtime *rt);
+static bool s2_clear_history(struct wms_runtime *rt);
 
 /*
  * FFI function table 
@@ -30,6 +31,7 @@ struct wms_ffi_func_tbl ffi_func_tbl[] = {
 	{s2_set_config, "s2_set_config", {"key", "value", NULL}},
 	{s2_reflect_msgbox_and_namebox_config, "s2_reflect_msgbox_and_namebox_config", {NULL}},
 	{s2_reflect_font_config, "s2_reflect_font_config", {NULL}},
+	{s2_clear_history, "s2_clear_history", {NULL}},
 };
 
 #define FFI_FUNC_TBL_SIZE (sizeof(ffi_func_tbl) / sizeof(ffi_func_tbl[0]))
@@ -168,6 +170,17 @@ static bool s2_reflect_font_config(struct wms_runtime *rt)
 	/* Re-initialize the font subsystem. */
 	if (!init_glyph())
 		return false;
+
+	return true;
+}
+
+/* Clear the message history. */
+static bool s2_clear_history(struct wms_runtime *rt)
+{
+	UNUSED_PARAMETER(rt);
+
+	/* Clear the message history. */
+	clear_history();
 
 	return true;
 }


### PR DESCRIPTION
- Fixed the bug that the Japanese "stop" specifier is not usable in the `@se` command
- Added the feature to clear the message history in WMS scripts
- Added a config to quote Japanese lines (`serif.quote`)