### PR TITLE
Suika2/12.12

### DIFF
--- a/build/macos/suika.xcodeproj/project.pbxproj
+++ b/build/macos/suika.xcodeproj/project.pbxproj
@@ -860,7 +860,7 @@
 				);
 				LIBRARY_SEARCH_PATHS = libroot/lib;
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
-				MARKETING_VERSION = 2.12.10;
+				MARKETING_VERSION = 2.12.11;
 				OTHER_CFLAGS = (
 					"-DXCODE",
 					"-ffast-math",
@@ -905,7 +905,7 @@
 				);
 				LIBRARY_SEARCH_PATHS = libroot/lib;
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
-				MARKETING_VERSION = 2.12.10;
+				MARKETING_VERSION = 2.12.11;
 				OTHER_CFLAGS = (
 					"-DXCODE",
 					"-ffast-math",

--- a/build/release/readme-en.html
+++ b/build/release/readme-en.html
@@ -170,13 +170,38 @@ Suika2 is an open-source, cross-platform visual novel development engine that al
 <ul>
   <li>Suika 2/12.12 19th June 2023
     <ul>
-      <li>Supported the Japanese () quotations (<code>serif.quote=1</code>) (Thanks to Ameno-san!)</li>
-      <li>Added the automatic removal of redundant Japanese quotations</li>
-      <li>Fixed a bug that the name box appears with bg command when <code>namebox.hidden=1</code></li>
-      <li>Enhancement of NVL style: fixed the behaviour of <code>msgbox.show.on.bg=1</code> and <code>msgbox.show.on.ch=1</code></li>
-      <li>Fixed a bug that Face/Skip/Auto don't appear while bg, ch, chs</li>
-      <li>Fixed a crash when <code>msgbox.dim=1</code> (regression bug with the introduction of name variables)</li>
-      <li>Fixed a bug that Suika2 couldn't continue lines in NVL mode (Thanks to MATSUNO-san!)</li>
+      <li>Improvements on the full screen style (NVL)
+        <ul>
+          <li>Fixed the line continuation (Thanks to MATSUNO-san!)</li>
+          <li>Fixed a crash when <code>msgbox.dim=1</code></li>
+          <li>Fixed a bug that the name box appears on the bg command when <code>namebox.hidden=1</code></li>
+        </ul>
+      </li>
+      <li>Improvements on Japanese quotations
+        <ul>
+          <li>Changed not to show square quotations for lines surrounded by round quotations when <code>serif.quote=1</code> (Thanks to Ameno-san!)</li>
+          <li>Changed to remove redundant square quotations in lines (Thanks to MATSUNO-san!)</li>
+        </ul>
+      </li>
+      <li>Improvements on the message box and the character face
+        <ul>
+          <li>Fixed a bug that the character face is not displayed on the bg command when <code>msgbox.show.on.bg=1</code></li>
+          <li>Fixed a bug that the character face is not displayed on the ch/chs commands when <code>msgbox.show.on.ch=1</code></li>
+          <li>Fixed a bug that the message box and the character face are not displayed on the shake command when <code>msgbox.show.on.bg=1</code></li>
+        </ul>
+      </li>
+      <li>Improvements on the collapsed system menu
+        <ul>
+          <li>Fixed a bug that the collapsed system menu is not displayed on the Auto/Skip mode when <code>sysmenu.transition=1</code></li>
+          <li>Fixed a bug that the collapsed system menu is not displayed on the shake command when <code>sysmenu.transition=1</code></li>
+          <li>Fixed a bug that the collapsed system menu is pointable on the Auto/Skip mode</li>
+        </ul>
+      </li>
+      <li>Improvements on the Auto/Skip banners
+        <ul>
+          <li>Fixed bugs that the Auto/Skip banners are not displayed on the shake command</li>
+        </ul>
+      </li>
     </ul>
   </li>
   <li>Suika 2/12.11 14th June 2023

--- a/build/release/readme-en.html
+++ b/build/release/readme-en.html
@@ -42,7 +42,7 @@
 </head>
 <body>
 
-<h1>Suika 2/12.11</h1>
+<h1>Suika 2/12.12</h1>
 <p>Copyright (c) 2023 the Suika2 Development Team. All rights reserved.</p>
 
 <h2>About Suika2</h2>
@@ -168,6 +168,16 @@ Suika2 is an open-source, cross-platform visual novel development engine that al
 
 <h2>Release History</h2>
 <ul>
+  <li>Suika 2/12.12 19th June 2023
+    <ul>
+      <li>Supported the Japanese () quotations (<code>serif.quote=1</code>) (Thanks to Ameno-san!)</li>
+      <li>Added the automatic removal of redundant Japanese quotations</li>
+      <li>Fixed the bug that the name box appears with bg command when <code>namebox.hidden=1</code></li>
+      <li>Enhancement of NVL style: fixed the behaviour of <code>msgbox.show.on.bg=1</code> and <code>msgbox.show.on.ch=1</code></li>
+      <li>Fixed the bug that Face/Skip/Auto don't appear while bg, ch, chs</li>
+      <li>Fixed the crash when <code>msgbox.dim=1</code> (regression bug with the introduction of name variables)</li>
+    </ul>
+  </li>
   <li>Suika 2/12.11 14th June 2023
     <ul>
       <li>Added the backspace feature to GUI (Thanks to Asatsuki-san!)</li>

--- a/build/release/readme-en.html
+++ b/build/release/readme-en.html
@@ -172,10 +172,11 @@ Suika2 is an open-source, cross-platform visual novel development engine that al
     <ul>
       <li>Supported the Japanese () quotations (<code>serif.quote=1</code>) (Thanks to Ameno-san!)</li>
       <li>Added the automatic removal of redundant Japanese quotations</li>
-      <li>Fixed the bug that the name box appears with bg command when <code>namebox.hidden=1</code></li>
+      <li>Fixed a bug that the name box appears with bg command when <code>namebox.hidden=1</code></li>
       <li>Enhancement of NVL style: fixed the behaviour of <code>msgbox.show.on.bg=1</code> and <code>msgbox.show.on.ch=1</code></li>
-      <li>Fixed the bug that Face/Skip/Auto don't appear while bg, ch, chs</li>
-      <li>Fixed the crash when <code>msgbox.dim=1</code> (regression bug with the introduction of name variables)</li>
+      <li>Fixed a bug that Face/Skip/Auto don't appear while bg, ch, chs</li>
+      <li>Fixed a crash when <code>msgbox.dim=1</code> (regression bug with the introduction of name variables)</li>
+      <li>Fixed a bug that Suika2 couldn't continue lines in NVL mode (Thanks to MATSUNO-san!)</li>
     </ul>
   </li>
   <li>Suika 2/12.11 14th June 2023

--- a/build/release/readme-en.html
+++ b/build/release/readme-en.html
@@ -42,7 +42,7 @@
 </head>
 <body>
 
-<h1>Suika 2/12.10</h1>
+<h1>Suika 2/12.11</h1>
 <p>Copyright (c) 2023 the Suika2 Development Team. All rights reserved.</p>
 
 <h2>About Suika2</h2>
@@ -168,6 +168,13 @@ Suika2 is an open-source, cross-platform visual novel development engine that al
 
 <h2>Release History</h2>
 <ul>
+  <li>Suika 2/12.11 14th June 2023
+    <ul>
+      <li>Added the backspace feature to GUI (Thanks to Asatsuki-san!)</li>
+      <li>Fixed transient backgounds on GUI-exit (Thanks to MATSUNO-san!)</li>
+      <li>Supported fixed character message colors with name variables (Thanks to MATSUNO-san!)</li>
+    </ul>
+  </li>
   <li>Suika 2/12.10 12th June 2023
     <ul>
       <li>Fixed the bug that Suika2 Pro didn't export the <code>wms</code> folder (Thanks to Ameno-san!)</li>

--- a/build/release/readme-jp.html
+++ b/build/release/readme-jp.html
@@ -164,13 +164,38 @@
 <ul>
   <li>Suika 2/12.12 2023/06/19
     <ul>
-      <li><code>serif.quote=1</code> を使用時に、カッコ（）で囲われたセリフにカギカッコを付加しないように修正 (Thanks to Ameno-san!)</li>
-      <li>履歴中のセリフの余分なカギカッコを除去するように動作を変更</li>
-      <li><code>namebox.hidden=1</code> のときに背景コマンドで名前ボックスが表示されてしまうバグを修正</li>
-      <li>全画面スタイル強化、 <code>msgbox.show.on.bg=1</code> および <code>msgbox.show.on.ch=1</code> の挙動のバグを修正</li>
-      <li>画面遷移中に描画を忘れていたキャラ(顔)/SKIPバナー/AUTOバナーを表示するように修正 (bg, ch, chs)</li>
-      <li>名前変数導入の影響で <code>msgbox.dim=1</code> を使用時にクラッシュするようになっていたバグを修正</li>
-      <li>全画面スタイルでセリフの継続ができないバグを修正 (Thanks to MATSUNO-san!)</li>
+      <li>全画面スタイルの全般的な改良
+        <ul>
+          <li>セリフの行継続のバグ修正 (Thanks to MATSUNO-san!)</li>
+          <li><code>msgbox.dim=1</code> を使用時にクラッシュするバグを修正</li>
+          <li><code>namebox.hidden=1</code> のときにbgコマンドで名前ボックスが表示されてしまうバグを修正</li>
+        </ul>
+      </li>
+      <li>セリフのカッコ/カギカッコの改良
+        <ul>
+          <li><code>serif.quote=1</code> のとき、カッコ（）で囲われたセリフにカギカッコを付加しないように修正 (Thanks to Ameno-san!)</li>
+          <li>履歴中のセリフの余分なカギカッコを除去するように変更 (Thanks to MATSUNO-san!)</li>
+        </ul>
+      </li>
+      <li>メッセージボックスとキャラ(顔)の表示の改良
+        <ul>
+          <li><code>msgbox.show.on.bg=1</code> のとき、bgコマンドでキャラ(顔)が表示されないバグを修正</li>
+          <li><code>msgbox.show.on.ch=1</code> のとき、ch/chsコマンドでキャラ(顔)が表示されないバグを修正</li>
+          <li><code>msgbox.show.on.bg=1</code> のとき、shakeコマンドでメッセージボックスとキャラ(顔)が表示されないバグを修正</li>
+        </ul>
+      </li>
+      <li>折りたたみシステムメニューの改良
+        <ul>
+          <li><code>sysmenu.transition=1</code> のとき、Auto/Skip中に折りたたみシステムメニューが描画されないバグを修正</li>
+          <li><code>sysmenu.transition=1</code> のとき、shake中に折りたたみシステムメニューが描画されないバグを修正</li>
+          <li>Auto/Skip中に折りたたみシステムメニューのポイント音が鳴るバグを修正</li>
+        </ul>
+      </li>
+      <li>Auto/Skipバナーの改良
+        <ul>
+          <li>shakeコマンドでAuto/Skipバナーが描画されないバグを修正</li>
+        </ul>
+      </li>
     </ul>
   </li>
   <li>Suika2/12.11 2023/06/14

--- a/build/release/readme-jp.html
+++ b/build/release/readme-jp.html
@@ -43,7 +43,7 @@
 </head>
 <body>
 
-<h1>Suika 2/12.11</h1>
+<h1>Suika 2/12.12</h1>
 <p>Copyright (c) 2023 the Suika2 Development Team. All rights reserved.</p>
 
 <h2>このソフトについて</h2>
@@ -162,14 +162,24 @@
 
 <h2>変更履歴</h2>
 <ul>
-  <li>Suika 2/12.11 2023/06/14
+  <li>Suika 2/12.12 2023/06/19
+    <ul>
+      <li><code>serif.quote=1</code> を使用時に、カッコ（）で囲われたセリフにカギカッコを付加しないように修正 (Thanks to Ameno-san!)</li>
+      <li>履歴中のセリフの余分なカギカッコを除去するように動作を変更</li>
+      <li><code>namebox.hidden=1</code> のときに背景コマンドで名前ボックスが表示されてしまうバグを修正</li>
+      <li>全画面スタイル強化、 <code>msgbox.show.on.bg=1</code> および <code>msgbox.show.on.ch=1</code> の挙動のバグを修正</li>
+      <li>画面遷移中に描画を忘れていたキャラ(顔)/SKIPバナー/AUTOバナーを表示するように修正 (bg, ch, chs)</li>
+      <li>名前変数導入の影響で <code>msgbox.dim=1</code> を使用時にクラッシュするようになっていたバグを修正</li>
+    </ul>
+  </li>
+  <li>Suika2/12.11 2023/06/14
     <ul>
       <li>GUIコマンドに名前編集の1文字消去機能を追加 (Thanks to Asatsuki-san!)</li>
       <li>GUIコマンド終了後の背景を修正 (Thanks to MATSUNO-san!)</li>
       <li>固定キャラクタ文字色を名前変数に対応 (Thanks to MATSUNO-san!)</li>
     </ul>
   </li>
-  <li>Suika 2/12.10 2023/06/12
+  <li>Suika2/12.10 2023/06/12
     <ul>
       <li><code>wms</code> フォルダがパッケージにエクスポートされない問題を修正 (Thanks to アメノ-san!)</li>
       <li>名前変数を導入 (<code>%a</code> から <code>%z</code> まで)</li>
@@ -177,58 +187,58 @@
       <li>WMSで <code>!=</code> の比較を実装し忘れていたのを修正</li>
     </ul>
   </li>
-  <li>Suika 2/12.9 2023/06/11
+  <li>Suika2/12.9 2023/06/11
     <ul>
       <li>メッセージ履歴でカギカッコが2つ出てしまうバグを修正 (Thanks to サイト-san!)</li>
       <li>キャラ/背景の変更中に折りたたみシステムメニューを表示するコンフィグ <code>sysmenu.transition</code> を追加 (Thanks to あさつき-san!)</li>
     </ul>
   </li>
-  <li>Suika 2/12.8 2023/06/11
+  <li>Suika2/12.8 2023/06/11
     <ul>
       <li>効果音コマンドで日本語の「停止」が使えない問題を修正 (Thanks to アメノ-san!)</li>
       <li>メッセージ履歴をクリアする機能を追加 (Thanks to アメノ-san!)</li>
       <li>日本語のセリフをカギカッコで囲うコンフィグ <code>serif.quote</code> を追加 (Thanks to サイト-san!)</li>
     </ul>
   </li>
-  <li>Suika 2/12.7 2023/06/10
+  <li>Suika2/12.7 2023/06/10
     <ul>
       <li>CHコマンドで日本語を使ったときのバグ修正(Thanks to SOrow-san!)</li>
       <li>メッセージョボックス非表示時にシステムメニューも非表示に(Thanks to Asatsuki-san!)</li>
     </ul>
   </li>
-  <li>Suika 2/12.6 2023/05/28
+  <li>Suika2/12.6 2023/05/28
     <ul>
       <li>BGMコマンドの修正(Thanks to SOrow-san!)</li>
       <li>ダブルクオーテーションと同様にシングルクオーテーションも利用可に</li>
     </ul>
   </li>
-  <li>Suika 2/12.5 2023/04/26
+  <li>Suika2/12.5 2023/04/26
     <ul>
       <li>フォントのふちどりを修正</li>
     </ul>
   </li>
-  <li>Suika 2/12.4 2023/03/27
+  <li>Suika2/12.4 2023/03/27
     <ul>
       <li>WMSを連続して呼んだときのバグを修正</li>
     </ul>
   </li>
-  <li>Suika 2/12.3 2023/03/26
+  <li>Suika2/12.3 2023/03/26
     <ul>
       <li>フォントをゲーム中に変更できる仕組みを導入</li>
     </ul>
   </li>
-  <li>Suika 2/12.2 2023/03/04
+  <li>Suika2/12.2 2023/03/04
     <ul>
       <li>ヒストリーとセーブ・ロードで文字が緑色になるバグを修正</li>
     </ul>
   </li>
-  <li>Suika 2/12.1 2023/01/28
+  <li>Suika2/12.1 2023/01/28
     <ul>
       <li>Kiraraに対応</li>
       <li>Macでパッケージをエクスポートできないバグを修正</li>
     </ul>
   </li>
-  <li>Suika 2/12.0 2023/01/08
+  <li>Suika2/12.0 2023/01/08
     <ul>
       <li>日本語コマンドに対応</li>
       <li>スクリプトの引数名に対応(従来通り省略可能)</li>
@@ -236,7 +246,7 @@
       <li>WMSでランダムな数値の取得に対応</li>
     </ul>
   </li>
-  <li>Suika 2/11.10 2022/12/29
+  <li>Suika2/11.10 2022/12/29
     <ul>
       <li>高度なスクリプトシステム WMS (Watermelon Script) を搭載</li>
       <li>WMSの使用例として、実行時のメッセージボックス変更に対応</li>

--- a/build/release/readme-jp.html
+++ b/build/release/readme-jp.html
@@ -43,7 +43,7 @@
 </head>
 <body>
 
-<h1>Suika 2/12.10</h1>
+<h1>Suika 2/12.11</h1>
 <p>Copyright (c) 2023 the Suika2 Development Team. All rights reserved.</p>
 
 <h2>このソフトについて</h2>
@@ -162,6 +162,13 @@
 
 <h2>変更履歴</h2>
 <ul>
+  <li>Suika 2/12.11 2023/06/14
+    <ul>
+      <li>GUIコマンドに名前編集の1文字消去機能を追加 (Thanks to Asatsuki-san!)</li>
+      <li>GUIコマンド終了後の背景を修正 (Thanks to MATSUNO-san!)</li>
+      <li>固定キャラクタ文字色を名前変数に対応 (Thanks to MATSUNO-san!)</li>
+    </ul>
+  </li>
   <li>Suika 2/12.10 2023/06/12
     <ul>
       <li><code>wms</code> フォルダがパッケージにエクスポートされない問題を修正 (Thanks to アメノ-san!)</li>

--- a/build/release/readme-jp.html
+++ b/build/release/readme-jp.html
@@ -170,6 +170,7 @@
       <li>全画面スタイル強化、 <code>msgbox.show.on.bg=1</code> および <code>msgbox.show.on.ch=1</code> の挙動のバグを修正</li>
       <li>画面遷移中に描画を忘れていたキャラ(顔)/SKIPバナー/AUTOバナーを表示するように修正 (bg, ch, chs)</li>
       <li>名前変数導入の影響で <code>msgbox.dim=1</code> を使用時にクラッシュするようになっていたバグを修正</li>
+      <li>全画面スタイルでセリフの継続ができないバグを修正 (Thanks to MATSUNO-san!)</li>
     </ul>
   </li>
   <li>Suika2/12.11 2023/06/14

--- a/build/web-kit/readme-en.html
+++ b/build/web-kit/readme-en.html
@@ -44,7 +44,7 @@
 <body>
 
 <h1>Suika2 for Web Browsers Distribution Kit</h1>
-<p>Rev.65 (Supports Suika 2/12.10)</p>
+<p>Rev.66 (Supports Suika 2/12.11)</p>
 <p>Copyright (c) 2023 the Suika2 Development Team. All rights reserved.</p>
 
 <h2>About this kit</h2>
@@ -101,6 +101,11 @@
 
 <h2>Revisions</h2>
 <ul>
+  <li>Rev.66 14th June 2023
+    <ul>
+      <li>Support Suika 2/12.11</li>
+    </ul>
+  </li>
   <li>Rev.65 12th June 2023
     <ul>
       <li>Support Suika 2/12.10</li>

--- a/build/web-kit/readme-en.html
+++ b/build/web-kit/readme-en.html
@@ -44,7 +44,7 @@
 <body>
 
 <h1>Suika2 for Web Browsers Distribution Kit</h1>
-<p>Rev.66 (Supports Suika 2/12.11)</p>
+<p>Rev.67 (Supports Suika2/12.12)</p>
 <p>Copyright (c) 2023 the Suika2 Development Team. All rights reserved.</p>
 
 <h2>About this kit</h2>
@@ -101,69 +101,74 @@
 
 <h2>Revisions</h2>
 <ul>
+  <li>Rev.67 19th June 2023
+    <ul>
+      <li>Support Suika2/12.12</li>
+    </ul>
+  </li>
   <li>Rev.66 14th June 2023
     <ul>
-      <li>Support Suika 2/12.11</li>
+      <li>Support Suika2/12.11</li>
     </ul>
   </li>
   <li>Rev.65 12th June 2023
     <ul>
-      <li>Support Suika 2/12.10</li>
+      <li>Support Suika2/12.10</li>
     </ul>
   </li>
   <li>Rev.64 11th June 2023
     <ul>
-      <li>Support Suika 2/12.9</li>
+      <li>Support Suika2/12.9</li>
     </ul>
   </li>
   <li>Rev.63 11th June 2023
     <ul>
-      <li>Support Suika 2/12.8</li>
+      <li>Support Suika2/12.8</li>
     </ul>
   </li>
   <li>Rev.62 10th June 2023
     <ul>
-      <li>Support Suika 2/12.7</li>
+      <li>Support Suika2/12.7</li>
     </ul>
   </li>
   <li>Rev.61 28th May 2023
     <ul>
-      <li>Support Suika 2/12.6</li>
+      <li>Support Suika2/12.6</li>
     </ul>
   </li>
   <li>Rev.60 26th April 2023
     <ul>
-      <li>Support Suika 2/12.5</li>
+      <li>Support Suika2/12.5</li>
     </ul>
   </li>
   <li>Rev.59 27th March 2023
     <ul>
-      <li>Support Suika 2/12.4</li>
+      <li>Support Suika2/12.4</li>
     </ul>
   </li>
   <li>Rev.58 26th March 2023
     <ul>
-      <li>Support Suika 2/12.3</li>
+      <li>Support Suika2/12.3</li>
     </ul>
   </li>
   <li>Rev.57 4th March 2023
     <ul>
-      <li>Support Suika 2/12.2</li>
+      <li>Support Suika2/12.2</li>
     </ul>
   </li>
   <li>Rev.56 28th January 2023
     <ul>
-      <li>Support Suika 2/12.1</li>
+      <li>Support Suika2/12.1</li>
     </ul>
   </li>
   <li>Rev.55 8th January 2023
     <ul>
-      <li>Support Suika 2/12.0</li>
+      <li>Support Suika2/12.0</li>
     </ul>
   </li>
   <li>Rev.54 29th December 2022
     <ul>
-      <li>Support Suika 2/11.10</li>
+      <li>Support Suika2/11.10</li>
     </ul>
   </li>
   <li>Rev.53 6th December 2022

--- a/build/web-kit/readme-jp.html
+++ b/build/web-kit/readme-jp.html
@@ -44,7 +44,7 @@
 <body>
 
 <h1>Suika2 Webブラウザ版 配布キット</h1>
-<p>Rev.66 (Suika 2/12.11対応)</p>
+<p>Rev.67 (Suika2/12.12対応)</p>
 <p>Copyright (c) 2023 the Suika2 Development Team. All rights reserved.</p>
 
 <h2>このキットについて</h2>
@@ -97,69 +97,74 @@
 
 <h2>変更履歴</h2>
 <ul>
+  <li>Rev.67 2023/6/19
+    <ul>
+      <li>Suika2/12.12に対応</li>
+    </ul>
+  </li>
   <li>Rev.66 2023/6/14
     <ul>
-      <li>Suika 2/12.11に対応</li>
+      <li>Suika2/12.11に対応</li>
     </ul>
   </li>
   <li>Rev.65 2023/6/12
     <ul>
-      <li>Suika 2/12.10に対応</li>
+      <li>Suika2/12.10に対応</li>
     </ul>
   </li>
   <li>Rev.64 2023/6/11
     <ul>
-      <li>Suika 2/12.9に対応</li>
+      <li>Suika2/12.9に対応</li>
     </ul>
   </li>
   <li>Rev.63 2023/6/11
     <ul>
-      <li>Suika 2/12.8に対応</li>
+      <li>Suika2/12.8に対応</li>
     </ul>
   </li>
   <li>Rev.62 2023/6/10
     <ul>
-      <li>Suika 2/12.7に対応</li>
+      <li>Suika2/12.7に対応</li>
     </ul>
   </li>
   <li>Rev.61 2023/5/28
     <ul>
-      <li>Suika 2/12.6に対応</li>
+      <li>Suika2/12.6に対応</li>
     </ul>
   </li>
   <li>Rev.60 2023/4/26
     <ul>
-      <li>Suika 2/12.5に対応</li>
+      <li>Suika2/12.5に対応</li>
     </ul>
   </li>
   <li>Rev.59 2023/3/27
     <ul>
-      <li>Suika 2/12.4に対応</li>
+      <li>Suika2/12.4に対応</li>
     </ul>
   </li>
   <li>Rev.58 2023/3/26
     <ul>
-      <li>Suika 2/12.3に対応</li>
+      <li>Suika2/12.3に対応</li>
     </ul>
   </li>
   <li>Rev.57 2023/3/4
     <ul>
-      <li>Suika 2/12.2に対応</li>
+      <li>Suika2/12.2に対応</li>
     </ul>
   </li>
   <li>Rev.56 2023/1/28
     <ul>
-      <li>Suika 2/12.1に対応</li>
+      <li>Suika2/12.1に対応</li>
     </ul>
   </li>
   <li>Rev.55 2023/1/8
     <ul>
-      <li>Suika 2/12.0に対応</li>
+      <li>Suika2/12.0に対応</li>
     </ul>
   </li>
   <li>Rev.54 2022/12/29
     <ul>
-      <li>Suika 2/11.10に対応</li>
+      <li>Suika2/11.10に対応</li>
     </ul>
   </li>
   <li>Rev.53 2022/12/6

--- a/build/web-kit/readme-jp.html
+++ b/build/web-kit/readme-jp.html
@@ -44,7 +44,7 @@
 <body>
 
 <h1>Suika2 Webブラウザ版 配布キット</h1>
-<p>Rev.65 (Suika 2/12.10対応)</p>
+<p>Rev.66 (Suika 2/12.11対応)</p>
 <p>Copyright (c) 2023 the Suika2 Development Team. All rights reserved.</p>
 
 <h2>このキットについて</h2>
@@ -97,6 +97,11 @@
 
 <h2>変更履歴</h2>
 <ul>
+  <li>Rev.66 2023/6/14
+    <ul>
+      <li>Suika 2/12.11に対応</li>
+    </ul>
+  </li>
   <li>Rev.65 2023/6/12
     <ul>
       <li>Suika 2/12.10に対応</li>

--- a/src/cmd_bg.c
+++ b/src/cmd_bg.c
@@ -141,8 +141,10 @@ static bool init(void)
 	}
 
 	/* メッセージボックスを消す */
-	show_namebox(false);
-	show_msgbox(false);
+	if (!conf_msgbox_show_on_bg) {
+		show_namebox(false);
+		show_msgbox(false);
+	}
 	show_click(false);
 	return true;
 }

--- a/src/cmd_message.c
+++ b/src/cmd_message.c
@@ -1027,17 +1027,16 @@ static int get_en_word_width(void)
 static void get_message_color(pixel_t *color, pixel_t *outline_color)
 {
 	int i;
-	const char *name;
+
+	assert(name_top != NULL);
 
 	/* セリフの場合 */
 	if (get_command_type() == COMMAND_SERIF) {
-		name = get_string_param(SERIF_PARAM_NAME);
-
 		/* コンフィグでnameの指す名前が指定されているか */
 		for (i = 0; i < SERIF_COLOR_COUNT; i++) {
 			if (conf_serif_color_name[i] == NULL)
 				continue;
-			if (strcmp(name, conf_serif_color_name[i]) == 0) {
+			if (strcmp(name_top, conf_serif_color_name[i]) == 0) {
 				/* コンフィグで指定された色にする */
 				*color = make_pixel_slow(
 					0xff,

--- a/src/cmd_message.c
+++ b/src/cmd_message.c
@@ -2346,12 +2346,6 @@ static bool is_skippable(void)
 /* 終了処理を行う */
 static bool cleanup(int *x, int *y, int *w, int *h)
 {
-	/* メッセージを解放する */
-	if (msg_top != NULL) {
-		free(msg_top);
-		msg_top = NULL;
-	}
-
 	/* PCMストリームの再生を終了する */
 	if (!conf_voice_stop_off)
 		set_mixer_input(VOICE_STREAM, NULL);
@@ -2387,6 +2381,12 @@ static bool cleanup(int *x, int *y, int *w, int *h)
 						(uint32_t)conf_msgbox_dim_color_outline_g,
 						(uint32_t)conf_msgbox_dim_color_outline_b);
 		draw_msgbox(x, y, w, h);
+	}
+
+	/* メッセージを解放する */
+	if (msg_top != NULL) {
+		free(msg_top);
+		msg_top = NULL;
 	}
 
 	/* 次のコマンドに移動する */

--- a/src/cmd_message.c
+++ b/src/cmd_message.c
@@ -1028,8 +1028,6 @@ static void get_message_color(pixel_t *color, pixel_t *outline_color)
 {
 	int i;
 
-	assert(name_top != NULL);
-
 	/* セリフの場合 */
 	if (get_command_type() == COMMAND_SERIF) {
 		/* コンフィグでnameの指す名前が指定されているか */

--- a/src/cmd_message.c
+++ b/src/cmd_message.c
@@ -310,6 +310,8 @@ bool message_command(int *x, int *y, int *w, int *h)
 	if (!conf_sysmenu_hidden && !is_hidden) {
 		if (is_sysmenu)
 			draw_sysmenu(false, x, y, w, h);
+		else if (conf_sysmenu_transition)
+			draw_collapsed_sysmenu(x, y, w, h);
 		else if (!is_auto_mode() && !is_skip_mode())
 			draw_collapsed_sysmenu(x, y, w, h);
 	}
@@ -2492,6 +2494,9 @@ static void draw_collapsed_sysmenu(int *x, int *y, int *w, int *h)
 static bool is_collapsed_sysmenu_pointed(void)
 {
 	int bx, by, bw, bh;
+
+	if (is_auto_mode() || is_skip_mode())
+		return false;
 
 	get_collapsed_sysmenu_rect(&bx, &by, &bw, &bh);
 	if (mouse_pos_x >= bx && mouse_pos_x < bx + bw &&

--- a/src/cmd_message.c
+++ b/src/cmd_message.c
@@ -372,7 +372,7 @@ static bool init(int *x, int *y, int *w, int *h)
 			log_memory();
 			return false;
 		}
-		if (conf_serif_quote) {
+		if (conf_serif_quote && !is_quoted_serif(exp_msg)) {
 			msg_top = quote_serif(exp_msg);
 			if (msg_top == NULL) {
 				log_memory();

--- a/src/cmd_shake.c
+++ b/src/cmd_shake.c
@@ -120,6 +120,7 @@ static bool get_move(const char *move_s)
 static void draw(void)
 {
 	float lap, t, s;
+	int x, y, w, h;
 
 	/* 経過時間を取得する */
 	lap = (float)get_stop_watch_lap(&sw) / 1000.0f;
@@ -160,6 +161,12 @@ static void draw(void)
 		draw_stage_shake();
 	else
 		draw_stage();
+
+	/* 折りたたみシステムメニューを描画する */
+	if (conf_sysmenu_transition && !is_non_interruptible()) {
+		x = y = w = h = 0;
+		draw_stage_collapsed_sysmenu(false, &x, &y, &w, &h);
+	}
 }
 
 /* 終了処理を行う */

--- a/src/gui.c
+++ b/src/gui.c
@@ -873,6 +873,11 @@ static bool move_to_other_gui(void)
 	}
 	free(file);
 
+	/* 終了後に表示されるBGレイヤを設定する */
+	if (!is_called_from_command)
+		if (!create_temporary_bg_for_gui())
+			return false;
+
 	/* GUIを開始する */
 	start_gui_mode();
 

--- a/src/gui.c
+++ b/src/gui.c
@@ -2283,6 +2283,12 @@ static void process_char(int index)
 		return;
 	}
 
+	/* 1文字消去ボタンの場合 */
+	if (strcmp(b->msg, "[backspace]") == 0) {
+		truncate_name_variable(b->namevar);
+		return;
+	}
+
 	/* 決定ボタンの場合 */
 	if (strcmp(b->msg, "[ok]") == 0) {
 		/* 名前変数が空白なら決定できない */

--- a/src/history.c
+++ b/src/history.c
@@ -97,7 +97,7 @@ bool register_message(const char *name, const char *msg, const char *voice)
 	/* 名前が指定されいる場合 */
 	if (name != NULL) {
 		/* "名前「メッセージ」"の形式に連結して保存する */
-		if (conf_locale == LOCALE_JA) {
+		if (conf_locale == LOCALE_JA || conf_serif_quote) {
 			/* 日本語 */
 			if (!is_quoted_serif(msg)) {
 				/* カッコがない場合 */

--- a/src/history.c
+++ b/src/history.c
@@ -98,9 +98,18 @@ bool register_message(const char *name, const char *msg, const char *voice)
 	if (name != NULL) {
 		/* "名前「メッセージ」"の形式に連結して保存する */
 		if (conf_locale == LOCALE_JA) {
-			snprintf(tmp_text, TEXT_SIZE, U8("%s「%s」"),
-				 name, msg);
+			/* 日本語 */
+			if (!is_quoted_serif(msg)) {
+				/* カッコがない場合 */
+				snprintf(tmp_text, TEXT_SIZE, U8("%s「%s」"),
+					 name, msg);
+			} else {
+				/* すでにカッコがある場合 */
+				snprintf(tmp_text, TEXT_SIZE, U8("%s%s"),
+					 name, msg);
+			}
 		} else {
+			/* 日本語以外 */
 			snprintf(tmp_text, TEXT_SIZE, "%s: %s", name, msg);
 		}
 		h->text = strdup(tmp_text);
@@ -200,4 +209,29 @@ const char *get_history_voice(int offset)
 	assert(index >= 0 && index < history_count);
 
 	return history[index].voice;
+}
+
+/*
+ * セリフがカッコで始まりカッコで終わるかチェックする
+ */
+bool is_quoted_serif(const char *msg)
+{
+	const char *round_prefix = U8("（");
+	const char *round_suffix = U8("）");
+	const char *square_prefix = U8("「");
+	const char *square_suffix = U8("」");
+
+	/* 全角カッコ（）を調べる */
+	if (strncmp(msg, round_prefix, strlen(round_prefix)) == 0 &&
+	    strncmp(msg + strlen(msg) - strlen(round_suffix), round_suffix,
+		    strlen(round_suffix)) == 0)
+		return true;
+
+	/* 全角カギカッコ「」を調べる */
+	if (strncmp(msg, square_prefix, strlen(square_prefix)) == 0 &&
+	    strncmp(msg + strlen(msg) - strlen(square_suffix), square_suffix,
+		    strlen(square_suffix)) == 0)
+		return true;
+
+	return false;
 }

--- a/src/history.h
+++ b/src/history.h
@@ -39,4 +39,7 @@ const char *get_history_message(int index);
 /* ヒストリのボイスを取得する */
 const char *get_history_voice(int index);
 
+/* セリフがカッコで始まりカッコで終わるかチェックする */
+bool is_quoted_serif(const char *msg);
+
 #endif

--- a/src/stage.c
+++ b/src/stage.c
@@ -970,17 +970,6 @@ void draw_stage_ch_fade(int fade_method)
 	assert(stage_mode == STAGE_MODE_CH_FADE);
 
 	draw_stage_fi_fo_fade(fade_method);
-
-	if (is_msgbox_visible)
-		render_layer_image(LAYER_MSG);
-	if (is_namebox_visible)
-		render_layer_image(LAYER_NAME);
-	if (is_msgbox_visible)
-		render_layer_image(LAYER_CHF);
-	if (is_auto_visible)
-		render_layer_image(LAYER_AUTO);
-	if (is_skip_visible)
-		render_layer_image(LAYER_SKIP);
 }
 
 /* FI/FOフェードを行う */
@@ -2559,10 +2548,18 @@ void start_bg_fade(struct image *img)
 	draw_layer_image(layer_image[LAYER_FO], LAYER_CHL);
 	draw_layer_image(layer_image[LAYER_FO], LAYER_CHR);
 	draw_layer_image(layer_image[LAYER_FO], LAYER_CHC);
-	if (conf_msgbox_show_on_bg && is_msgbox_visible) {
-		draw_layer_image(layer_image[LAYER_FO], LAYER_MSG);
-		draw_layer_image(layer_image[LAYER_FO], LAYER_NAME);
+	if (conf_msgbox_show_on_bg) {
+		if (is_msgbox_visible)
+			draw_layer_image(layer_image[LAYER_FO], LAYER_MSG);
+		if (is_namebox_visible && !conf_namebox_hidden)
+			draw_layer_image(layer_image[LAYER_FO], LAYER_NAME);
+		if (is_msgbox_visible)
+			draw_layer_image(layer_image[LAYER_FO], LAYER_CHF);
 	}
+	if (is_auto_visible)
+		draw_layer_image(layer_image[LAYER_FO], LAYER_AUTO);
+	if (is_skip_visible)
+		draw_layer_image(layer_image[LAYER_FO], LAYER_SKIP);
 	unlock_image(layer_image[LAYER_FO]);
 
 	/* フェードイン用のレイヤにイメージをセットする */
@@ -2572,10 +2569,18 @@ void start_bg_fade(struct image *img)
 	lock_image(layer_image[LAYER_FI]);
 	draw_image(layer_image[LAYER_FI], 0, 0, img, conf_window_width,
 		   conf_window_height, 0, 0, 255, BLEND_NONE);
-	if (conf_msgbox_show_on_bg && is_msgbox_visible) {
-		draw_layer_image(layer_image[LAYER_FI], LAYER_MSG);
-		draw_layer_image(layer_image[LAYER_FI], LAYER_NAME);
+	if (conf_msgbox_show_on_bg) {
+		if (is_msgbox_visible)
+			draw_layer_image(layer_image[LAYER_FI], LAYER_MSG);
+		if (is_namebox_visible && !conf_namebox_hidden)
+			draw_layer_image(layer_image[LAYER_FI], LAYER_NAME);
+		if (is_msgbox_visible)
+			draw_layer_image(layer_image[LAYER_FI], LAYER_CHF);
 	}
+	if (is_auto_visible)
+		draw_layer_image(layer_image[LAYER_FI], LAYER_AUTO);
+	if (is_skip_visible)
+		draw_layer_image(layer_image[LAYER_FI], LAYER_SKIP);
 	unlock_image(layer_image[LAYER_FI]);
 
 	/* 無効になるレイヤのイメージを破棄する */
@@ -2584,6 +2589,8 @@ void start_bg_fade(struct image *img)
 	destroy_layer_image(LAYER_CHL);
 	destroy_layer_image(LAYER_CHR);
 	destroy_layer_image(LAYER_CHC);
+	if (!conf_msgbox_show_on_bg)
+		destroy_layer_image(LAYER_CHF);
 }
 
 /*
@@ -2735,6 +2742,16 @@ void start_ch_fade(int pos, struct image *img, int x, int y, int alpha)
 	draw_layer_image(layer_image[LAYER_FO], LAYER_CHL);
 	draw_layer_image(layer_image[LAYER_FO], LAYER_CHR);
 	draw_layer_image(layer_image[LAYER_FO], LAYER_CHC);
+	if (is_msgbox_visible)
+		draw_layer_image(layer_image[LAYER_FO], LAYER_MSG);
+	if (is_namebox_visible && !conf_namebox_hidden)
+		draw_layer_image(layer_image[LAYER_FO], LAYER_NAME);
+	if (is_msgbox_visible)
+		draw_layer_image(layer_image[LAYER_FO], LAYER_CHF);
+	if (is_auto_visible)
+		draw_layer_image(layer_image[LAYER_FO], LAYER_AUTO);
+	if (is_skip_visible)
+		draw_layer_image(layer_image[LAYER_FO], LAYER_SKIP);
 	unlock_image(layer_image[LAYER_FO]);
 
 	/* キャラを入れ替える */
@@ -2752,6 +2769,16 @@ void start_ch_fade(int pos, struct image *img, int x, int y, int alpha)
 	draw_layer_image(layer_image[LAYER_FI], LAYER_CHL);
 	draw_layer_image(layer_image[LAYER_FI], LAYER_CHR);
 	draw_layer_image(layer_image[LAYER_FI], LAYER_CHC);
+	if (is_msgbox_visible)
+		draw_layer_image(layer_image[LAYER_FI], LAYER_MSG);
+	if (is_namebox_visible && !conf_namebox_hidden)
+		draw_layer_image(layer_image[LAYER_FI], LAYER_NAME);
+	if (is_msgbox_visible)
+		draw_layer_image(layer_image[LAYER_FI], LAYER_CHF);
+	if (is_auto_visible)
+		draw_layer_image(layer_image[LAYER_FI], LAYER_AUTO);
+	if (is_skip_visible)
+		draw_layer_image(layer_image[LAYER_FI], LAYER_SKIP);
 	unlock_image(layer_image[LAYER_FI]);
 }
 
@@ -2794,6 +2821,10 @@ void start_ch_fade_multi(const bool *stay, struct image **img, const int *x,
 	draw_layer_image(layer_image[LAYER_FO], LAYER_CHL);
 	draw_layer_image(layer_image[LAYER_FO], LAYER_CHR);
 	draw_layer_image(layer_image[LAYER_FO], LAYER_CHC);
+	if (is_msgbox_visible)
+		draw_layer_image(layer_image[LAYER_FO], LAYER_MSG);
+	if (is_namebox_visible && !conf_namebox_hidden)
+		draw_layer_image(layer_image[LAYER_FO], LAYER_NAME);
 	unlock_image(layer_image[LAYER_FO]);
 
 	/* キャラを入れ替える */
@@ -2821,6 +2852,10 @@ void start_ch_fade_multi(const bool *stay, struct image **img, const int *x,
 	draw_layer_image(layer_image[LAYER_FI], LAYER_CHL);
 	draw_layer_image(layer_image[LAYER_FI], LAYER_CHR);
 	draw_layer_image(layer_image[LAYER_FI], LAYER_CHC);
+	if (is_msgbox_visible)
+		draw_layer_image(layer_image[LAYER_FI], LAYER_MSG);
+	if (is_namebox_visible && !conf_namebox_hidden)
+		draw_layer_image(layer_image[LAYER_FI], LAYER_NAME);
 	unlock_image(layer_image[LAYER_FI]);
 }
 

--- a/src/stage.c
+++ b/src/stage.c
@@ -955,11 +955,6 @@ void draw_stage_bg_fade(int fade_method)
 	assert(stage_mode == STAGE_MODE_BG_FADE);
 
 	draw_stage_fi_fo_fade(fade_method);
-
-	if (is_auto_visible)
-		render_layer_image(LAYER_AUTO);
-	if (is_skip_visible)
-		render_layer_image(LAYER_SKIP);
 }
 
 /*
@@ -1931,6 +1926,11 @@ void draw_stage_shake(void)
 	render_image(shake_offset_x, shake_offset_y,
 		     layer_image[LAYER_FI], conf_window_width,
 		     conf_window_height, 0, 0, 255, BLEND_NONE);
+
+	if (is_auto_visible)
+		render_layer_image(LAYER_AUTO);
+	if (is_skip_visible)
+		render_layer_image(LAYER_SKIP);
 }
 
 /*
@@ -3017,6 +3017,14 @@ void start_shake(void)
 	draw_layer_image(layer_image[LAYER_FI], LAYER_CHL);
 	draw_layer_image(layer_image[LAYER_FI], LAYER_CHR);
 	draw_layer_image(layer_image[LAYER_FI], LAYER_CHC);
+	if (conf_msgbox_show_on_bg) {
+		if (is_msgbox_visible)
+			draw_layer_image(layer_image[LAYER_FI], LAYER_MSG);
+		if (is_namebox_visible && !conf_namebox_hidden)
+			draw_layer_image(layer_image[LAYER_FI], LAYER_NAME);
+		if (is_msgbox_visible)
+			draw_layer_image(layer_image[LAYER_FI], LAYER_CHF);
+	}
 	unlock_image(layer_image[LAYER_FI]);
 }
 

--- a/src/stage.c
+++ b/src/stage.c
@@ -2548,14 +2548,12 @@ void start_bg_fade(struct image *img)
 	draw_layer_image(layer_image[LAYER_FO], LAYER_CHL);
 	draw_layer_image(layer_image[LAYER_FO], LAYER_CHR);
 	draw_layer_image(layer_image[LAYER_FO], LAYER_CHC);
-	if (conf_msgbox_show_on_bg) {
-		if (is_msgbox_visible)
-			draw_layer_image(layer_image[LAYER_FO], LAYER_MSG);
-		if (is_namebox_visible && !conf_namebox_hidden)
-			draw_layer_image(layer_image[LAYER_FO], LAYER_NAME);
-		if (is_msgbox_visible)
-			draw_layer_image(layer_image[LAYER_FO], LAYER_CHF);
-	}
+	if (is_msgbox_visible)
+		draw_layer_image(layer_image[LAYER_FO], LAYER_MSG);
+	if (is_namebox_visible && !conf_namebox_hidden)
+		draw_layer_image(layer_image[LAYER_FO], LAYER_NAME);
+	if (is_msgbox_visible)
+		draw_layer_image(layer_image[LAYER_FO], LAYER_CHF);
 	if (is_auto_visible)
 		draw_layer_image(layer_image[LAYER_FO], LAYER_AUTO);
 	if (is_skip_visible)
@@ -2589,8 +2587,6 @@ void start_bg_fade(struct image *img)
 	destroy_layer_image(LAYER_CHL);
 	destroy_layer_image(LAYER_CHR);
 	destroy_layer_image(LAYER_CHC);
-	if (!conf_msgbox_show_on_bg)
-		destroy_layer_image(LAYER_CHF);
 }
 
 /*
@@ -2742,12 +2738,14 @@ void start_ch_fade(int pos, struct image *img, int x, int y, int alpha)
 	draw_layer_image(layer_image[LAYER_FO], LAYER_CHL);
 	draw_layer_image(layer_image[LAYER_FO], LAYER_CHR);
 	draw_layer_image(layer_image[LAYER_FO], LAYER_CHC);
-	if (is_msgbox_visible)
-		draw_layer_image(layer_image[LAYER_FO], LAYER_MSG);
-	if (is_namebox_visible && !conf_namebox_hidden)
-		draw_layer_image(layer_image[LAYER_FO], LAYER_NAME);
-	if (is_msgbox_visible)
-		draw_layer_image(layer_image[LAYER_FO], LAYER_CHF);
+	if (conf_msgbox_show_on_ch) {
+		if (is_msgbox_visible)
+			draw_layer_image(layer_image[LAYER_FO], LAYER_MSG);
+		if (is_namebox_visible && !conf_namebox_hidden)
+			draw_layer_image(layer_image[LAYER_FO], LAYER_NAME);
+		if (is_msgbox_visible)
+			draw_layer_image(layer_image[LAYER_FO], LAYER_CHF);
+	}
 	if (is_auto_visible)
 		draw_layer_image(layer_image[LAYER_FO], LAYER_AUTO);
 	if (is_skip_visible)
@@ -2769,12 +2767,14 @@ void start_ch_fade(int pos, struct image *img, int x, int y, int alpha)
 	draw_layer_image(layer_image[LAYER_FI], LAYER_CHL);
 	draw_layer_image(layer_image[LAYER_FI], LAYER_CHR);
 	draw_layer_image(layer_image[LAYER_FI], LAYER_CHC);
-	if (is_msgbox_visible)
-		draw_layer_image(layer_image[LAYER_FI], LAYER_MSG);
-	if (is_namebox_visible && !conf_namebox_hidden)
-		draw_layer_image(layer_image[LAYER_FI], LAYER_NAME);
-	if (is_msgbox_visible)
-		draw_layer_image(layer_image[LAYER_FI], LAYER_CHF);
+	if (conf_msgbox_show_on_ch) {
+		if (is_msgbox_visible)
+			draw_layer_image(layer_image[LAYER_FI], LAYER_MSG);
+		if (is_namebox_visible && !conf_namebox_hidden)
+			draw_layer_image(layer_image[LAYER_FI], LAYER_NAME);
+		if (is_msgbox_visible)
+			draw_layer_image(layer_image[LAYER_FI], LAYER_CHF);
+	}
 	if (is_auto_visible)
 		draw_layer_image(layer_image[LAYER_FI], LAYER_AUTO);
 	if (is_skip_visible)

--- a/src/stage.c
+++ b/src/stage.c
@@ -2821,10 +2821,18 @@ void start_ch_fade_multi(const bool *stay, struct image **img, const int *x,
 	draw_layer_image(layer_image[LAYER_FO], LAYER_CHL);
 	draw_layer_image(layer_image[LAYER_FO], LAYER_CHR);
 	draw_layer_image(layer_image[LAYER_FO], LAYER_CHC);
-	if (is_msgbox_visible)
-		draw_layer_image(layer_image[LAYER_FO], LAYER_MSG);
-	if (is_namebox_visible && !conf_namebox_hidden)
-		draw_layer_image(layer_image[LAYER_FO], LAYER_NAME);
+	if (conf_msgbox_show_on_ch) {
+		if (is_msgbox_visible)
+			draw_layer_image(layer_image[LAYER_FO], LAYER_MSG);
+		if (is_namebox_visible && !conf_namebox_hidden)
+			draw_layer_image(layer_image[LAYER_FO], LAYER_NAME);
+		if (is_msgbox_visible)
+			draw_layer_image(layer_image[LAYER_FO], LAYER_CHF);
+	}
+	if (is_auto_visible)
+		draw_layer_image(layer_image[LAYER_FO], LAYER_AUTO);
+	if (is_skip_visible)
+		draw_layer_image(layer_image[LAYER_FO], LAYER_SKIP);
 	unlock_image(layer_image[LAYER_FO]);
 
 	/* キャラを入れ替える */
@@ -2852,10 +2860,18 @@ void start_ch_fade_multi(const bool *stay, struct image **img, const int *x,
 	draw_layer_image(layer_image[LAYER_FI], LAYER_CHL);
 	draw_layer_image(layer_image[LAYER_FI], LAYER_CHR);
 	draw_layer_image(layer_image[LAYER_FI], LAYER_CHC);
-	if (is_msgbox_visible)
-		draw_layer_image(layer_image[LAYER_FI], LAYER_MSG);
-	if (is_namebox_visible && !conf_namebox_hidden)
-		draw_layer_image(layer_image[LAYER_FI], LAYER_NAME);
+	if (conf_msgbox_show_on_ch) {
+		if (is_msgbox_visible)
+			draw_layer_image(layer_image[LAYER_FI], LAYER_MSG);
+		if (is_namebox_visible && !conf_namebox_hidden)
+			draw_layer_image(layer_image[LAYER_FI], LAYER_NAME);
+		if (is_msgbox_visible)
+			draw_layer_image(layer_image[LAYER_FI], LAYER_CHF);
+	}
+	if (is_auto_visible)
+		draw_layer_image(layer_image[LAYER_FI], LAYER_AUTO);
+	if (is_skip_visible)
+		draw_layer_image(layer_image[LAYER_FI], LAYER_SKIP);
 	unlock_image(layer_image[LAYER_FI]);
 }
 

--- a/src/vars.c
+++ b/src/vars.c
@@ -196,6 +196,29 @@ bool set_name_variable(int index, const char *val)
 }
 
 /*
+ * 名前変数の最後の文字を消去する
+ */
+void truncate_name_variable(int index)
+{
+	char *s;
+	uint32_t wc;
+	int i, len;
+
+	assert(index >= 0 && index < NAME_VAR_SIZE);
+
+	s = name_var_tbl[index];
+	if (s == NULL)
+		return;
+
+	len = utf8_chars(s);
+
+	for (i = 0; i < len - 1; i++)
+		s += utf8_to_utf32(s, &wc);
+
+	*s = '\0';
+}
+
+/*
  * 文字列の中の変数を展開して返す
  */
 const char *expand_variable(const char *msg)

--- a/src/vars.h
+++ b/src/vars.h
@@ -60,6 +60,9 @@ const char *get_name_variable(int index);
 /* 名前変数を設定する */
 bool set_name_variable(int index, const char *val);
 
+/* 名前変数の最後の文字を消去する */
+void truncate_name_variable(int index);
+
 /* 文字列の中の変数を展開して返す */
 const char *expand_variable(const char *msg);
 


### PR DESCRIPTION
- Improvements on the full screen style (NVL)
  - Fixed the line continuation (Thanks to MATSUNO-san!)
  - Fixed a crash when `msgbox.dim=1`
  - Fixed a bug that the name box appears on the bg command when `namebox.hidden=1`
- Improvements on Japanese quotations
  - Changed not to show square quotations for lines surrounded by round quotations when `serif.quote=1` (Thanks to Ameno-san!)
  - Changed to remove redundant square quotations in lines (Thanks to MATSUNO-san!)
- Improvements on the message box and the character face
  - Fixed a bug that the character face is not displayed on the `bg` command when `msgbox.show.on.bg=1`
  - Fixed a bug that the character face is not displayed on the `ch`/`chs` commands when `msgbox.show.on.ch=1`
  - Fixed a bug that the message box and the character face are not displayed on the shake command when `msgbox.show.on.bg=1`
- Improvements on the collapsed system menu
  - Fixed a bug that the collapsed system menu is not displayed on the Auto/Skip mode when `sysmenu.transition=1`
  - Fixed a bug that the collapsed system menu is not displayed on the shake command when `sysmenu.transition=1`
  - Fixed a bug that the collapsed system menu is pointable on the Auto/Skip mode
- Improvements on the Auto/Skip banners
  - Fixed bugs that the Auto/Skip banners are not displayed on the shake command