### PR TITLE
Add Commonwealth English Snippets

### DIFF
--- a/snippets/en-cwn-normal/plaintext.code-snippets
+++ b/snippets/en-cwn-normal/plaintext.code-snippets
@@ -1,0 +1,908 @@
+{
+	//シナリオ
+	"bg":{
+		"prefix": ["@bg","@背景"],
+		"body": "@bg file=$1 duration=$2 effect=$3",
+		"description": "Show Background Image @bg <file or HEX-colour-code> (duration) (エフェクト)"
+	},
+	"bgm":{
+		"prefix": ["@bgm","@音楽"],
+		"body": "@bgm file=$1 $2",
+		"description": "Play Background Music @bgm <file or stop> (once)"
+	},
+	"ch":{
+		"prefix": ["@ch","@キャラ"],
+		"body": "@ch position=$1 file=$2 duration=$3 effect=$4 right=$5 down=$6 alpha=$7",
+		"description": "Show Character Image, Supports 'centre' Position Variant @ch <position> <file> (duration) (effect) (right-offset) (down-offset) (alpha)"
+	},
+	"cha":{
+		"prefix": ["@cha","@キャラ移動"],
+		"body": "@cha position=$1 duration=$2 acceleration=$3 x=$4 y=$5 alpha=$6",
+		"description": "Move a Character @cha <position> <duration> <acceleration> (x) (y) (alpha)"
+	},
+	"chapter":{
+		"prefix": ["@chapter","@章"],
+		"body":"@chapter title=$1",
+		"description": "Set Chapter Title @chapter <title>"
+	},
+	"choose":{
+		"prefix": ["@choose","@選択肢"],
+		"body":"@choose destination1=$1 option1=$2 destination2=$3 option2=$4",
+		"description": "Show Options @choose <Label1> <Option1> (Label2) (Option2) (Label3) (Option3) (Label4) (Option4) (Label5) (Option5) (Label6) (Option6) (Label)7 (Option7) (Label8) (Option8)"
+	},
+	"chs":{
+		"prefix": ["@chs","@場面転換"],
+		"body":"@chs center=$1 right=$2 left=$3 back=$4 duration=$5 background=$6 effect=$7",
+		"description": "Change Stage @chs <center-file or stay or none> <right-file or stay or none> <left-file or stay or none> <back-file or stay or none> (duration) (background-file) (effect)"
+	},
+	"click":{
+		"prefix": ["@click","@クリック"],
+		"body":"@click",
+		"description": "Wait for a Click @click"
+	},
+	"gosub":{
+		"prefix": ["@gosub"],
+		"body":"@gosub $1",
+		"description": "Go to Subroutine @gosub <label>"
+	},
+	"goto":{
+		"prefix": ["@goto","@ジャンプ"],
+		"body":"@goto destination=$1",
+		"description": "Jump to a Label @goto <label>"
+	},
+	"gui":{
+		"prefix": ["@gui","@メニュー"],
+		"body":"@gui file=$1 $2",
+		"description": "Show GUI @gui <file> (cancel)"
+	},
+	"if":{
+		"prefix": ["@if","@フラグでジャンプ"],
+		"body":"@if $1 $2 $3 $4",
+		"description": "Jump by Condition @if <variable> <condition> <value> <label>"
+	},
+	"load":{
+		"prefix": ["@load","@シナリオ"],
+		"body":"@load file=$1",
+		"description": "Load Other Script @load <file>"
+	},
+	"return":{
+		"prefix": ["@return"],
+		"body": "@return",
+		"description": "Return from a Subroutine @return"
+	},
+	"se":{
+		"prefix": ["@se"],
+		"body": "@se file=$1 $2",
+		"description": "Play Sound Effect (44.1kHz Ogg Vorbis) @se <file> (loop or voice)"
+	},
+	"set":{
+		"prefix": ["@set","@フラグをセット"],
+		"body":"@set $1 $2 $3",
+		"description": "Set Variable @set <variable> <operator> <value>"
+	},
+	"setsave":{
+		"prefix": ["@setsave"],
+		"body":"@setsave $1",
+		"description": "Enable/disable save and load @setsave <enable/disable>"
+	},
+	"shake":{
+		"prefix": ["@shake","@振動"],
+		"body": "@shake direction=$1 duration=$2 times=$3 amplitude=$4",
+		"description": "Shake Screen @shake <direction> <duration> <times> <amplitude>"
+	},
+	"skip":{
+		"prefix": ["@skip","@スキップ"],
+		"body": "@skip $1",
+		"description": "Enable/disable Skip @skip <enable/disable>"
+	},
+	"video":{
+		"prefix": ["@video","@動画"],
+		"body": "@video file=$1",
+		"description": "Play Video @video <file>"
+	},
+	"vol":{
+		"prefix": ["@vol","@音量"],
+		"body": "@vol track=$1 volume=$2 duration=$3",
+		"description": "Set Volume for a Track @vol <track> <volume> (duration)"
+	},
+	"wait":{
+		"prefix": ["@wait","@時間待ち"],
+		"body": "@wait duration=$1",
+		"description": "Wait for Seconds @wait <duration>"
+	},
+	"wms":{
+		"prefix": ["@wms","@スクリプト"],
+		"body": "@wms file=$1",
+		"description": "Run WMS @wms <file>"
+	},
+	//エフェクト名
+	"normal":{
+		"prefix": ["normal","標準"],
+		"body": "normal",
+		"description": "Effect: normal"
+	},
+	"rule":{
+		"prefix": ["rule"],
+		"body": "rule:$1",
+		"description": "Effect:rule(1bit) rule:file"
+	},
+	"melt":{
+		"prefix": ["melt"],
+		"body": "melt:$1",
+		"description": "Effect:rule(8bit) melt:file"
+	},
+	"curtain-right":{
+		"prefix": ["curtain-right","右カーテン"],
+		"body": "curtain-right",
+		"description": "Effect: Right Curtain"
+	},
+	"curtain-left":{
+		"prefix": ["curtain-left","左カーテン"],
+		"body": "curtain-left",
+		"description": "Effect: Left Curtain"
+	},
+	"curtain-up":{
+		"prefix": ["curtain-up","上カーテン"],
+		"body": "curtain-up",
+		"description": "Effect: Up Curtain"
+	},
+	"curtain-down":{
+		"prefix": ["curtain-down","下カーテン"],
+		"body": "curtain-down",
+		"description": "Effect: Down Curtain"
+	},
+	"slide-right":{
+		"prefix": ["slide-right","右スライド"],
+		"body": "slide-right",
+		"description": "Effect: Right Slide"
+	},
+	"slide-left":{
+		"prefix": ["slide-left","左スライド"],
+		"body": "slide-left",
+		"description": "Effect: Left Slide"
+	},
+	"slide-up":{
+		"prefix": ["slide-up","上スライド"],
+		"body": "slide-up",
+		"description": "Effect: Up Slide"
+	},
+	"slide-down":{
+		"prefix": ["slide-down","下スライド"],
+		"body": "slide-down",
+		"description": "Effect: Down Slide"
+	},
+	"shutter-right":{
+		"prefix": ["shutter-right","右シャッター"],
+		"body": "shutter-right",
+		"description": "Effect: Right Shutter"
+	},
+	"shutter-left":{
+		"prefix": ["shutter-left","左シャッター"],
+		"body": "shutter-left",
+		"description": "Effect: Left Shutter"
+	},
+	"shutter-up":{
+		"prefix": ["shutter-up","上シャッター"],
+		"body": "shutter-up",
+		"description": "Effect: Up Shutter"
+	},
+	"shutter-down":{
+		"prefix": ["shutter-down","下シャッター"],
+		"body": "shutter-down",
+		"description": "Effect: Down Shutter"
+	},
+	"clockwise":{
+		"prefix": ["clockwise","時計回り"],
+		"body": "clockwise",
+		"description": "Effect: Clockwise"
+	},
+	"counterclockwise":{
+		"prefix": ["counterclockwise","反時計回り"],
+		"body": "counterclockwise",
+		"description": "Effect: Counterclockwise"
+	},
+	"clockwise20":{
+		"prefix": ["clockwise20"],
+		"body": "clockwise20",
+		"description": "Effect: Clockwise (20deg)"
+	},
+	"counterclockwise20":{
+		"prefix": ["counterclockwise20"],
+		"body": "counterclockwise20",
+		"description": "Effect: Counterclockwise (20deg)"
+	},
+	"clockwise30":{
+		"prefix": ["clockwise30"],
+		"body": "clockwise30",
+		"description": "Effect: Clockwise (30deg)"
+	},
+	"counterclockwise30":{
+		"prefix": ["counterclockwise30"],
+		"body": "counterclockwise30",
+		"description": "Effect: Counterclockwise (30deg)"
+	},
+	"eye-open":{
+		"prefix": ["eye-open"],
+		"body": "eye-open",
+		"description": "Effect: Open Eye"
+	},
+	"eye-close":{
+		"prefix": ["eye-close"],
+		"body": "eye-close",
+		"description": "Effect: Close Eye"
+	},
+	"eye-open-v":{
+		"prefix": ["eye-open-v"],
+		"body": "eye-open-v",
+		"description": "Effect: Open Eye (Vertical)"
+	},
+	"eye-close-v":{
+		"prefix": ["eye-close-v"],
+		"body": "eye-close-v",
+		"description": "Effect: Close Eye (Vertical)"
+	},
+	"slit-open":{
+		"prefix": ["slit-open"],
+		"body": "slit-open",
+		"description": "Effect: Slip Open"
+	},
+	"slit-close":{
+		"prefix": ["slit-close"],
+		"body": "slit-close",
+		"description": "Effect: Slit Close"
+	},
+	"slit-open-v":{
+		"prefix": ["slit-open-v"],
+		"body": "slit-open-v",
+		"description": "Effect: Slit Open (Vertical)"
+	},
+	"slit-close-v":{
+		"prefix": ["slit-close-v"],
+		"body": "slit-close-v",
+		"description": "Effect: Slit Close (Vertical)"
+	},
+	//gui
+	"globalTemp":{
+		"prefix": "global",
+		"body": [
+			"global {",
+			"\tidle: $1;",
+			"\thover: $2",
+			"\tactive: $3;",
+			"",
+			"\tcancelse: $4;",
+			"}"
+		],
+		"description": "Template for global section of GUI"
+	},
+	"gotoTemp":{
+		"prefix": "gotoTemp",
+		"body": [
+			"$1 {",
+			"\ttype: goto;",
+			"",
+			"\tlabel: $2;",
+			"",
+			"\tx: $3;",
+			"\ty: $4;",
+			"\twidth: $5;",
+			"\theight: $6;",
+			"",
+			"\tpointse: $7;",
+			"\tclickse: $8;",
+			"}"
+		],
+		"description": "Template for goto button"
+	},
+	"textspeedTemp":{
+		"prefix": "textspeedTemp",
+		"body": [
+			"$1 {",
+			"\ttype: textspeed;",
+			"",
+			"\tx: $3;",
+			"\ty: $4;",
+			"\twidth: $5;",
+			"\theight: $6;",
+			"",
+			"\tpointse: $7;",
+			"}"
+		],
+		"description": "Template for textspeed slider"
+	},
+	"autospeedTemp":{
+		"prefix": "autospeedTemp",
+		"body": [
+			"$1 {",
+			"\ttype: autospeed;",
+			"",
+			"\tlabel: $2;",
+			"",
+			"\tx: $3;",
+			"\ty: $4;",
+			"\twidth: $5;",
+			"\theight: $6;",
+			"",
+			"\tpointse: $7;",
+			"\tclickse: $8;",
+			"}"
+		],
+		"description": "Template for autospeed slider"
+	},
+	"previewTemp":{
+		"prefix": "previewTemp",
+		"body": [
+			"$1 {",
+			"\ttype: preview;",
+			"",
+			"\tmsg: ${2:This is a preview message. Is the message speed ok?};",
+			"",
+			"\tx: $3;",
+			"\ty: $4;",
+			"\twidth: $5;",
+			"\theight: $6;",
+			"}"
+		],
+		"description": "Template for preview area"
+	},
+	"bgmvolTemp":{
+		"prefix": "previewTemp",
+		"body": [
+			"$1 {",
+			"\ttype: bgmvol;",
+			"",
+			"\tx: $2;",
+			"\ty: $3;",
+			"\twidth: $4;",
+			"\theight: $5;",
+			"",
+			"\tpointse: $6;",
+			"}"
+		],
+		"description": "Template for bgmvol slider"
+	},
+	"sevolTemp":{
+		"prefix": "sevolTemp",
+		"body": [
+			"$1 {",
+			"\ttype: sevol;",
+			"",
+			"\tfile:$2",
+			"",
+			"\tx: $3;",
+			"\ty: $4;",
+			"\twidth: $5;",
+			"\theight: $6;",
+			"",
+			"\tpointse: $7;",
+			"}"
+		],
+		"description": "Template for sevol slider"
+	},
+	"voicevolTemp":{
+		"prefix": "voicevolTemp",
+		"body": [
+			"$1 {",
+			"\ttype: voicevol;",
+			"",
+			"\tfile:$2",
+			"",
+			"\tx: $3;",
+			"\ty: $4;",
+			"\twidth: $5;",
+			"\theight: $6;",
+			"",
+			"\tpointse: $7;",
+			"}"
+		],
+		"description": "Template for voicevol button"
+	},
+	"charactervolTemp":{
+		"prefix": "charactervolTemp",
+		"body": [
+			"$1 {",
+			"\ttype: charactervol;",
+			"",
+			"\tindex: $2",
+			"",
+			"\tfile:$3",
+			"",
+			"\tx: $4;",
+			"\ty: $5;",
+			"\twidth: $6;",
+			"\theight: $7;",
+			"",
+			"\tpointse: $8;",
+			"}"
+		],
+		"description": "Template for charactervol button"
+	},
+	"fontTemp":{
+		"prefix": "fontTemp",
+		"body": [
+			"$1 {",
+			"\ttype: font;",
+			"",
+			"\tfile:$2",
+			"",
+			"\tx: $3;",
+			"\ty: $4;",
+			"\twidth: $5;",
+			"\theight: $6;",
+			"",
+			"\tpointse: $7;",
+			"\tclickse: $8;",
+			"}"
+		],
+		"description": "Template for font button"
+	},
+	"fullscreenTemp":{
+		"prefix": "fullscreenTemp",
+		"body": [
+			"$1 {",
+			"\ttype: fullscreen;",
+			"",
+			"\tx: $2;",
+			"\ty: $3;",
+			"\twidth: $4;",
+			"\theight: $5;",
+			"",
+			"\tpointse: $6;",
+			"\tclickse: $7;",
+			"}"
+		],
+		"description": "Template for fullscreen button"
+	},
+	"windowTemp":{
+		"prefix": "windowTemp",
+		"body": [
+			"$1 {",
+			"\ttype: window;",
+			"",
+			"\tx: $2;",
+			"\ty: $3;",
+			"\twidth: $4;",
+			"\theight: $5;",
+			"",
+			"\tpointse: $6;",
+			"\tclickse: $7;",
+			"}"
+		],
+		"description": "Template for window button"
+	},
+	"defaultTemp":{
+		"prefix": "defaultTemp",
+		"body": [
+			"$1 {",
+			"\ttype: default;",
+			"",
+			"\tx: $2;",
+			"\ty: $3;",
+			"\twidth: $4;",
+			"\theight: $5;",
+			"",
+			"\tpointse: $6;",
+			"\tclickse: $7;",
+			"}"
+		],
+		"description": "Template for default button"
+	},
+	"guiTemp":{
+		"prefix": "guiTemp",
+		"body": [
+			"$1 {",
+			"\ttype: gui;",
+			"",
+			"\tfile:$2",
+			"",
+			"\tx: $3;",
+			"\ty: $4;",
+			"\twidth: $5;",
+			"\theight: $6;",
+			"",
+			"\tpointse: $7;",
+			"\tclickse: $8;",
+			"}"
+		],
+		"description": "Template for type:gui button"
+	},
+	"titleTemp":{
+		"prefix": "titleTemp",
+		"body": [
+			"$1 {",
+			"\ttype: title;",
+			"",
+			"\tfile:$2",
+			"",
+			"\tx: $3;",
+			"\ty: $4;",
+			"\twidth: $5;",
+			"\theight: $6;",
+			"",
+			"\tpointse: $7;",
+			"\tclickse: $8;",
+			"}"
+		],
+		"description": "Template for type:title button"
+	},
+	"cancelTemp":{
+		"prefix": "cancelTemp",
+		"body": [
+			"$1 {",
+			"\ttype: cancel;",
+			"",
+			"\tx: $2;",
+			"\ty: $3;",
+			"\twidth: $4;",
+			"\theight: $5;",
+			"",
+			"\tpointse: $6;",
+			"\tclickse: $7;",
+			"}"
+		],
+		"description": "Template for cancel button"
+	},
+	"savepageTemp":{
+		"prefix": "savepageTemp",
+		"body": [
+			"$1 {",
+			"\ttype: savepage;",
+			"",
+			"\tindex: $2",
+			"",
+			"\tx: $3;",
+			"\ty: $4;",
+			"\twidth: $5;",
+			"\theight: $6;",
+			"",
+			"\tpointse: $7;",
+			"\tclickse: $8;",
+			"}"
+		],
+		"description": "Template for savepage button"
+	},
+	"saveTemp":{
+		"prefix": "saveTemp",
+		"body": [
+			"$1 {",
+			"\ttype: save;",
+			"",
+			"\tindex: $2",
+			"",
+			"\tx: $3;",
+			"\ty: $4;",
+			"\twidth: $5;",
+			"\theight: $6;",
+			"",
+			"\tmargin: $7",
+			"",
+			"\tpointse: $8;",
+			"\tclickse: $9;",
+			"}"
+		],
+		"description": "Template for save area"
+	},
+	"loadTemp":{
+		"prefix": "loadTemp",
+		"body": [
+			"$1 {",
+			"\ttype: load;",
+			"",
+			"\tindex: $2",
+			"",
+			"\tx: $3;",
+			"\ty: $4;",
+			"\twidth: $5;",
+			"\theight: $6;",
+			"",
+			"\tmargin: $7",
+			"",
+			"\tpointse: $8;",
+			"\tclickse: $9;",
+			"}"
+		],
+		"description": "Template for load area"
+	},
+	"historyscrollTemp":{
+		"prefix": "historyscrollTemp",
+		"body": [
+			"$1 {",
+			"\ttype: historyscroll;",
+			"",
+			"\tx: $2;",
+			"\ty: $3;",
+			"\twidth: $4;",
+			"\theight: $5;",
+			"",
+			"\tpointse: $6;",
+			"}"
+		],
+		"description": "Template for historyscroll bar"
+	},
+	"historyTemp":{
+		"prefix": "historyTemp",
+		"body": [
+			"$1 {",
+			"\ttype: history;",
+			"",
+			"\tindex: $2",
+			"",
+			"\tx: $3;",
+			"\ty: $4;",
+			"\twidth: $5;",
+			"\theight: $6;",
+			"",
+			"\tmargin: $7",
+			"",
+			"\tpointse: $8;",
+			"}"
+		],
+		"description": "Template for history item"
+	},
+	"namevarTemp":{
+		"prefix": "namevarTemp",
+		"body":[			
+			"$1 {",
+			"\ttype: namevar;",
+			"",
+			"\tnamevar: $2",
+			"",
+			"\tx: $3;",
+			"\ty: $4;",
+			"\twidth: $5;",
+			"\theight: $6;",
+			"}"
+		],
+		"description": "Template for namevar area"
+	},
+	"charTemp":{
+		"prefix": "charTemp",
+		"body":[			
+			"$1 {",
+			"\ttype: char;",
+			"",
+			"\tnamevar: $2",
+			"",
+			"\tmsg: $3;",
+			"",
+			"\tmax: $4",
+			"",
+			"\tx: $5;",
+			"\ty: $6;",
+			"\twidth: $7;",
+			"\theight: $8;",
+			"",
+			"\tpointse: $9",
+			"",
+			"\tclickse: $10",
+			"}"
+		],
+		"description": "Template for name input button"
+	},
+	"charOKTemp":{
+		"prefix": "charOKTemp",
+		"body":[			
+			"$1 {",
+			"\ttype: char;",
+			"",
+			"\tnamevar: $2",
+			"",
+			"\tmsg: [ok];",
+			"",
+			"\tmax: $3",
+			"",
+			"\tx: $4;",
+			"\ty: $5;",
+			"\twidth: $6;",
+			"\theight: $7;",
+			"",
+			"\tpointse: $8",
+			"",
+			"\tclickse: $9",
+			"}"
+		],
+		"description": "Template for name input complete button"
+	},
+	"charClearTemp":{
+		"prefix": "charClearTemp",
+		"body":[			
+			"$1 {",
+			"\ttype: char;",
+			"",
+			"\tnamevar: $2",
+			"",
+			"\tmsg: [clear];",
+			"",
+			"\tmax: $3",
+			"",
+			"\tx: $4;",
+			"\ty: $5;",
+			"\twidth: $6;",
+			"\theight: $7;",
+			"",
+			"\tpointse: $8",
+			"",
+			"\tclickse: $9",
+			"}"
+		],
+		"description": "Template for name input clear button"
+	},
+	"charBackspaceTemp":{
+		"prefix": "charBackspaceTemp",
+		"body":[			
+			"$1 {",
+			"\ttype: char;",
+			"",
+			"\tnamevar: $2",
+			"",
+			"\tmsg: [backspace];",
+			"",
+			"\tmax: $3",
+			"",
+			"\tx: $4;",
+			"\ty: $5;",
+			"\twidth: $6;",
+			"\theight: $7;",
+			"",
+			"\tpointse: $8",
+			"",
+			"\tclickse: $9",
+			"}"
+		],
+		"description": "Template for name input backspace button"
+	},
+	"galleryTemp":{
+		"prefix": "galleryTemp",
+		"body":[			
+			"$1 {",
+			"\ttype: gallery;",
+			"",
+			"\tlabel: $2",
+			"",
+			"\tvar: $3",
+			"",
+			"\tx: $4;",
+			"\ty: $5;",
+			"\twidth: $6;",
+			"\theight: $7;",
+			"",
+			"\tpointse: $8",
+			"",
+			"\tclickse: $9",
+			"}"
+		],
+		"description": "Template for CG gallery button"
+	},
+	//wms
+	"func":{
+		"prefix": "func",
+		"body":[
+			"func $1() {",
+			"\t$2",
+			"}"
+		],
+		"description": "Function definition"
+	},
+	"main":{
+		"prefix": "main()",
+		"body":[
+			"func main() {",
+			"\t$1",
+			"}"
+		],
+		"description": "WMS starts from this function"
+	},
+	"print":{
+		"prefix": "print()",
+		"body":[
+			"print($1);"
+		],
+		"description": "Show alert"
+	},
+	"for":{
+		"prefix": "for()",
+		"body":[
+			"for($1){",
+			"\t$2",
+			"}"
+		],
+		"description": "Repeat for"
+	},
+	"while":{
+		"prefix": "while()",
+		"body":[
+			"while($1){",
+			"\t$2",
+			"}"
+		],
+		"description": "Repeat while"
+	},
+	"ifWms":{
+		"prefix": "if()",
+		"body":[
+			"if($1){",
+			"\t$2",
+			"}"
+		],
+		"description": "If block"
+	},
+	"else":{
+		"prefix": "if()",
+		"body":[
+			"else {",
+			"\t$1",
+			"}"
+		],
+		"description": "Else block"
+	},
+	"break":{
+		"prefix": "break",
+		"body":[
+			"break;"
+		],
+		"description": "Break loop"
+	},
+	"continue":{
+		"prefix": "continue",
+		"body":[
+			"continue;"
+		],
+		"description": "Continue loop"
+	},
+	"remove":{
+		"prefix": "remove();",
+		"body":[
+			"remove($1);"
+		],
+		"description": "Remove an array element"
+	},
+	"size":{
+		"prefix": "size();",
+		"body":[
+			"size($1);"
+		],
+		"description": "Get size of array"
+	},
+	"s2_get_variable":{
+		"prefix": "s2_get_variable();",
+		"body":[
+			"s2_get_variable($1);"
+		],
+		"description": "Get engine variable value"
+	},
+	"s2_set_variable":{
+		"prefix": "s2_set_variable();",
+		"body":[
+			"s2_set_variable($1,$2);"
+		],
+		"description": "Set engine variable value"
+	},
+	"s2_set_config":{
+		"prefix": "s2_set_config();",
+		"body":[
+			"s2_set_config($1,$2);"
+		],
+		"description": "Overwrite config item"
+	},
+	"s2_reflect_config":{
+		"prefix": "s2_reflect_",
+		"body":[
+			"s2_reflect_$1_config();"
+		],
+		"description": "Apply change of config overwrite"
+	},
+	"s2_reflect_font_config":{
+		"prefix": "s2_reflect_font_config();",
+		"body":[
+			"s2_reflect_font_config();"
+		],
+		"description": "Apply font config change"
+	},
+	"s2_reflect_msgbox_and_namebox_config":{
+		"prefix": "s2_reflect_msgbox_and_namebox_config();",
+		"body":[
+			"s2_reflect_msgbox_and_namebox_config();"
+		],
+		"description": "Apply message box and name box config change"
+	}
+}


### PR DESCRIPTION
Minor changes to reflect Commonwealth English variant spelling in one or two supported commands and descriptions.

Changed words (Where appropriate):

color –> colour
center -> centre

Please let me know if file/folder naming conventions are incorrect, and I can fix them!