### PR TITLE
Fix `.DS_Store` showing up on Mac

### DIFF
--- a/tools/kirara/src/main.js
+++ b/tools/kirara/src/main.js
@@ -86,7 +86,7 @@ ipcMain.handle('getGameList', (event) => {
     // ゲームフォルダの一覧を返す
     var ret = [];
     fs.readdirSync(path).forEach(function(file) {
-        if(ret !== ".DS_Store") {
+        if(file !== ".DS_Store") {
             ret.push(file);
         }
     });


### PR DESCRIPTION
Was still seeing `.DS_Store` files in the Kirara project list, so changed the field to `file` rather than `ret`.

Feel free to reject if there is a better solution.